### PR TITLE
add `onTouchStart` to pretty-text-input

### DIFF
--- a/build/lib/components/helpers/pretty-text-input.js
+++ b/build/lib/components/helpers/pretty-text-input.js
@@ -268,7 +268,8 @@ module.exports = React.createClass({
     // Render read-only version.
     return React.createElement(
       'div',
-      { onKeyDown: this.onKeyDown, className: cx({ 'pretty-text-wrapper': true, 'choices-open': this.state.isChoicesOpen }), onMouseEnter: this.switchToCodeMirror },
+      { onKeyDown: this.onKeyDown, className: cx({ 'pretty-text-wrapper': true, 'choices-open': this.state.isChoicesOpen }),
+        onMouseEnter: this.switchToCodeMirror, onTouchStart: this.switchToCodeMirror },
       React.createElement(
         'div',
         { className: textBoxClasses, tabIndex: this.wrapperTabIndex(),

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -259,7 +259,8 @@ module.exports = React.createClass({
 
     // Render read-only version.
     return (
-      <div onKeyDown={this.onKeyDown} className={cx({'pretty-text-wrapper': true, 'choices-open': this.state.isChoicesOpen})} onMouseEnter={this.switchToCodeMirror}>
+      <div onKeyDown={this.onKeyDown} className={cx({'pretty-text-wrapper': true, 'choices-open': this.state.isChoicesOpen})}
+           onMouseEnter={this.switchToCodeMirror} onTouchStart={this.switchToCodeMirror}>
         <div className={textBoxClasses} tabIndex={this.wrapperTabIndex()}
              onFocus={this.onFocusWrapper} onBlur={this.onBlur}>
           <div ref="textBox" className="internal-text-wrapper" />


### PR DESCRIPTION
Tested this in Chrome's device simulator, and with this change, clicking an input box to the right of a pretty pill correctly places the cursor directly to the right of the pill as expected.

With change:
![](https://zapier.cachefly.net/storage/photos/1e9c945da36f0fbef8b01fd70cd1944b.png)

Previously:
![](https://zapier.cachefly.net/storage/photos/e7aa56e457d42d649ddc11df66af9ba2.png)

edit: this will need an `npm version patch` &mdash; not sure if I should add that to this PR or do it separately