### PR TITLE
Fix how placeholders work in PrettyTextInput

### DIFF
--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -316,14 +316,11 @@ module.exports = React.createClass({
   },
 
   createCodeMirrorEditor: function () {
-    const value = this.hasPlaceholder() ?
-                  String(this.props.config.fieldPlaceholder(this.props.field)) :
-                  String(this.state.value);
-
     var options = {
       tabindex: this.props.tabIndex || 0,
       lineWrapping: true,
-      value: value,
+      placeholder: toString(this.props.config.fieldPlaceholder(this.props.field)),
+      value: toString(this.state.value),
       readOnly: false,
       mode: null,
       extraKeys: {
@@ -394,7 +391,7 @@ module.exports = React.createClass({
 
   /* Return true if we should render the placeholder */
   hasPlaceholder: function () {
-    return !this.state.hasChanged && this.props.field.placeholder && !this.state.value;
+    return !this.state.value;
   },
 
   createReadonlyEditor: function () {


### PR DESCRIPTION
- Use `placeholder` option instead of always using `value`
- Simplify `hasPlaceholder` to `!this.state.value` rather than checking
`hasChanged`, etc. This doesn't appear to have any negative side
effects.