### PR TITLE
Add ability to customize fieldset form wrapper

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -23,7 +23,7 @@
    }
   </style>
 </head>
-<bodby>
+<body>
   <div class="container-fluid">
     <div id="user"></div>
     <div id="extra"></div>

--- a/demo/index.js
+++ b/demo/index.js
@@ -12,6 +12,7 @@ var plugin = function (config) {
 
   var initField = config.initField;
   var createElement_PrettyTag = config.createElement_PrettyTag;
+  var createFieldset = config.createElement_Fieldset;
 
   config.createElement_PrettyTag = function (props, children) {
     //var choice = _.find(this.props.replaceChoices, (c) => c.value === tag);
@@ -50,13 +51,18 @@ var plugin = function (config) {
     },
 
     createElement_Fieldset: function (props, ...children) {
-      const newProps = { children };
-      return (
-        <div className="test-custom-fieldset">
-          <p>I'm a custom fieldset!</p>
-          <div {...newProps} />
-        </div>
-      );
+      if (props.config.useCustomFieldset) {
+        const newProps = { children };
+
+        return (
+          <div className="test-custom-fieldset">
+            <p>I have a custom fieldset!</p>
+            <div {...newProps} />
+          </div>
+        );
+      }
+
+      return createFieldset(props, ...children);
     }
   };
 };
@@ -420,35 +426,59 @@ var onOrderGroceries = function (info) {
   console.log('ordering...', info);
 };
 
-//fields = [
-//{type: 'pretty-text', key: 'a', label: 'pretty'},
-//{type: 'pretty-text', key: 'b', label: 'pretty'},
-//{type: 'pretty-text', key: 'c', label: 'pretty'}
-//];
+const formTwoConfig = Formatic.createConfig(
+  Formatic.plugins.reference,
+  Formatic.plugins.meta,
+  Formatic.plugins.bootstrap,
+  plugin
+);
+
+formTwoConfig.useCustomFieldset = true;
+
+const formTwo = {
+  config: formTwoConfig,
+  fields: [
+    {type: 'pretty-text', key: 'a', label: 'pretty'}
+  ],
+  value: {}
+};
 
 // Controlled version:
 
 var render = function (value) {
   window.value = value;
-  ReactDOM.render(Form({
-    meta: {msg: "That's a fine name you have there!"},
-    config: config,
-    fields: fields,
-    value: value,
-    onChange: function (newValue, info) {
-      console.log('new value:', newValue);
-      console.log('info:', info);
-      formValue = newValue;
-      render(newValue);
-    },
-    onFocus: onFocus,
-    onBlur: onBlur,
-    onOpenReplacements: onOpenReplacements,
-    onCloseReplacements: onCloseReplacements,
-    onClearCurrentChoice: onClearCurrentChoice,
-    onOrderGroceries: onOrderGroceries,
-    readOnly: false
-  }), document.getElementById('user'));
+  ReactDOM.render((
+    <div>
+      <h1>Form #1 - Examples</h1>
+      <Form
+        meta={{msg: "That's a fine name you have there!"}}
+        config={config}
+        fields={fields}
+        value={value}
+        onChange={function (newValue, info) {
+          console.log('new value:', newValue);
+          console.log('info:', info);
+          formValue = newValue;
+          render(newValue);
+        }}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onOpenReplacements={onOpenReplacements}
+        onCloseReplacements={onCloseReplacements}
+        onClearCurrentChoice={onClearCurrentChoice}
+        onOrderGroceries={onOrderGroceries}
+        readOnly={false}
+      />
+
+      <h1>Form #2 - Custom Fieldset</h1>
+      <Form
+        config={formTwo.config}
+        fields={formTwo.fields}
+        value={formTwo.value}
+        readOnly={true}
+      />
+    </div>
+  ), document.getElementById('user'));
 };
 
 var setValue = function (value) {

--- a/demo/index.js
+++ b/demo/index.js
@@ -47,6 +47,16 @@ var plugin = function (config) {
 
     isRemovalOfLastAssocListItemAllowed(/*field*/) {
       return false;
+    },
+
+    createElement_Fieldset: function (props, ...children) {
+      const newProps = { children };
+      return (
+        <div className="test-custom-fieldset">
+          <p>I'm a custom fieldset!</p>
+          <div {...newProps} />
+        </div>
+      );
     }
   };
 };

--- a/lib/components/fields/fields.js
+++ b/lib/components/fields/fields.js
@@ -7,9 +7,7 @@ Render a field to edit the values of an object with static properties.
 'use strict';
 
 var React = require('react');
-var R = React.DOM;
 var _ = require('../../undash');
-var cx = require('classnames');
 
 module.exports = React.createClass({
 
@@ -53,24 +51,35 @@ module.exports = React.createClass({
       classes['child-fields-group'] = true;
     }
 
+    const help = !isGroup ? null : config.createElement('help', {
+      config: config, field: field
+    });
+
+    const legend = !isGroup ? null : (
+      <legend>{config.fieldLabel(field)}</legend>
+    );
+
+    const content = fields.map(function (childField, i) {
+      var key = childField.key || i;
+      return config.createFieldElement({
+        key: key || i,
+        field: childField,
+        onChange: this.onChangeField.bind(this, childField.key), onAction: this.onBubbleAction
+      });
+    }.bind(this));
+
     return config.createElement('field', {
       config: config, field: field, plain: isGroup || this.props.plain
     },
-      R.fieldset({className: cx(classes)},
-        isGroup ? <legend>{config.fieldLabel(field)}</legend> : null,
-        isGroup ? (
-          config.createElement('help', {
-            config: config, field: field
-          })
-        ) : null,
-        fields.map(function (childField, i) {
-          var key = childField.key || i;
-          return config.createFieldElement({
-            key: key || i,
-            field: childField,
-            onChange: this.onChangeField.bind(this, childField.key), onAction: this.onBubbleAction
-          });
-        }.bind(this))
+      config.createElement('fieldset',
+        {
+          config: config,
+          field: field,
+          classes: classes
+        },
+        help,
+        legend,
+        content
       )
     );
   }

--- a/lib/components/helpers/fieldset.js
+++ b/lib/components/helpers/fieldset.js
@@ -1,0 +1,26 @@
+// # fieldset component
+
+/**
+ * Wraps the form in a fieldset
+ */
+'use strict';
+
+var React = require('react');
+var cx = require('classnames');
+
+module.exports = React.createClass({
+
+  displayName: 'Fieldset',
+
+  mixins: [require('../../mixins/helper')],
+
+  render: function () {
+    return this.renderWithConfig();
+  },
+
+  renderDefault: function () {
+    return (
+      <fieldset {...this.props} className={cx(this.props.classes)} />
+    );
+  }
+});

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -70,6 +70,8 @@ module.exports = function (config) {
 
     createElement_Field: React.createFactory(require('./components/helpers/field')),
 
+    createElement_Fieldset: React.createFactory(require('./components/helpers/fieldset')),
+
     createElement_Label: React.createFactory(require('./components/helpers/label')),
 
     createElement_Help: React.createFactory(require('./components/helpers/help')),
@@ -266,8 +268,7 @@ module.exports = function (config) {
     },
 
     // Create an element given a name, props, and children.
-    createElement: function (name, props, children) {
-
+    createElement: function (name, props, ...children) {
       if (!props.config) {
         props = _.extend({}, props, {config: config});
       }
@@ -275,12 +276,12 @@ module.exports = function (config) {
       name = config.elementName(name);
 
       if (config['createElement_' + name]) {
-        return config['createElement_' + name](props, children);
+        return config['createElement_' + name](props, ...children);
       }
 
       if (name !== 'Unknown') {
         if (config.hasElementFactory('Unknown')) {
-          return config.createElement('Unknown', props, children);
+          return config.createElement('Unknown', props, ...children);
         }
       }
 

--- a/lib/plugins/bootstrap.js
+++ b/lib/plugins/bootstrap.js
@@ -37,7 +37,7 @@ module.exports = function (config) {
   var createElement = config.createElement;
 
   return {
-    createElement: function (name, props, children) {
+    createElement: function (name, props, ...children) {
 
       name = config.elementName(name);
 
@@ -52,7 +52,7 @@ module.exports = function (config) {
         }
       }
 
-      return createElement(name, props, children);
+      return createElement(name, props, ...children);
     }
   };
 };

--- a/lib/plugins/element-classes.js
+++ b/lib/plugins/element-classes.js
@@ -28,7 +28,7 @@ module.exports = function (config) {
     },
 
     // Wrap the createElement method.
-    createElement: function (name, props, children) {
+    createElement: function (name, props, ...children) {
 
       name = config.elementName(name);
 
@@ -36,7 +36,7 @@ module.exports = function (config) {
         props = _.extend({}, props, {classes: elementClasses[name]});
       }
 
-      return createElement(name, props, children);
+      return createElement(name, props, ...children);
     }
   };
 };


### PR DESCRIPTION
@jdeal can you provide feedback on this PR? 

It seemed a bit odd that I had to wrap the `children` in a `<div>`, is there a way to avoid this? passing them as separate args was not working as expected.

I plan to remove the example plugin when this is confirmed 🆗 

