### PR TITLE
Support choices number values

### DIFF
--- a/lib/components/helpers/choices.js
+++ b/lib/components/helpers/choices.js
@@ -283,7 +283,7 @@ module.exports = React.createClass({
       } else if (_.isNull(choice.sectionKey)) {
         isInSection = false;
       }
-      if (choice.value && choice.value.match(magicChoiceRe)) {
+      if (choice.value && String(choice.value).match(magicChoiceRe)) {
         visibleChoices.push(choice);
       } else if (alwaysExanded || choice.sectionKey || isInOpenSection || !isInSection) {
         visibleChoices.push(choice);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formatic",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "description": "Automatic, pluggable form generation",
   "main": "./build/lib/formatic",
   "scripts": {


### PR DESCRIPTION
Fix bug when choice values are numbers. Previously we weren't hitting this, because values were always strings. However, now that we allow accordions in pretty selects, we can hit this.