### PR TITLE
Remove falsey values from choices in normalizeChoices

### DIFF
--- a/__tests__/undash.js
+++ b/__tests__/undash.js
@@ -10,6 +10,17 @@ describe('utils', () => {
     expect(_.flatten([['foo', 'bar'], 'baz'])).toEqual(['foo', 'bar', 'baz']);
   });
 
+  it('should compact', () => {
+
+    expect(_.compact([])).toEqual([]);
+    expect(_.compact(null)).toEqual([]);
+    expect(_.compact(undefined)).toEqual([]);
+    expect(_.compact([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(_.compact([0, 1, 2, 3, NaN, null, undefined, false])).toEqual([1, 2, 3]);
+    expect(() => _.compact('asdf')).toThrow();
+    expect(() => _.compact({})).toThrow();
+  });
+
   it('should each over object', () => {
 
     var obj = {a: 1, b: 2};

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1050,7 +1050,7 @@ module.exports = function (config) {
       choices = choices.slice(0);
 
       // Array of choice arrays should be flattened.
-      choices = _.flatten(choices);
+      choices = _.compact(_.flatten(choices));
 
       choices.forEach(function (choice, i) {
         // Convert any string choices to objects with `value` and `label`

--- a/lib/undash.js
+++ b/lib/undash.js
@@ -7,6 +7,7 @@ _.isEqual = require('deep-equal');
 // what's used in formatic.
 
 _.flatten = (arrays) => [].concat.apply([], arrays);
+_.compact = (array) => (array || []).filter(Boolean);
 
 _.isString = value => typeof value === 'string';
 _.isUndefined = value => typeof value === 'undefined';


### PR DESCRIPTION
It's possible that `null` values are sent for instance, and
`normalizeChoices` throws when that happens because we try to access
`label` off of `null` a little bit below this LOC. Ideally we would
always receive good `choices` but we need to handle cases where choices
are invalid.