### PR TITLE
Only force focus when click to focus, to avoid endless focus fighting loop

### DIFF
--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -127,17 +127,24 @@ module.exports = React.createClass({
     }
   },
 
-  onFocusWrapper: function () {
+  onFocusClick: function () {
+    this.onFocusWrapper(true);
+  },
+
+  onFocusWrapper: function (isFromClick) {
     this.switchToCodeMirror(() => {
       this.codeMirror.focus();
       this.codeMirror.setCursor(this.codeMirror.lineCount(), 0);
     }, () => {
-      setTimeout(() => {
-        if (this.codeMirror && !this.codeMirror.state.focused) {
-          this.codeMirror.focus();
-          this.codeMirror.setCursor(this.codeMirror.lineCount(), 0);
-        }
-      }, 0);
+      // If this is from a click, we lose focus, so force it focused!
+      if (isFromClick) {
+        setTimeout(() => {
+          if (this.codeMirror && !this.codeMirror.state.focused) {
+            this.codeMirror.focus();
+            this.codeMirror.setCursor(this.codeMirror.lineCount(), 0);
+          }
+        }, 0);
+      }
     });
   },
 
@@ -274,8 +281,8 @@ module.exports = React.createClass({
     return (
       <div onKeyDown={this.onKeyDown} className={cx({'pretty-text-wrapper': true, 'choices-open': this.state.isChoicesOpen})}
            onMouseEnter={this.switchToCodeMirror} onTouchStart={this.switchToCodeMirror}>
-        <div onClick={this.onFocusWrapper}>
-          <div className={textBoxClasses} tabIndex={this.wrapperTabIndex()} onFocus={this.onFocusWrapper} onBlur={this.onBlur}>
+        <div onClick={this.onFocusClick}>
+          <div className={textBoxClasses} tabIndex={this.wrapperTabIndex()} onFocus={this.onFocusWrap} onBlur={this.onBlur}>
             <div ref="textBox" className="internal-text-wrapper" />
           </div>
         </div>


### PR DESCRIPTION
This fixes a weird bug where:

1. You focus on a pretty text input.
2. You lose window focus by clicking into developer tools. (Probably other ways to do this too.)
3. You click on a different input.
4. That caused the two inputs to endlessly cycle.

That was because of a previous fix to allow clicking the wrapper border. To make that work, I had to focus codemirror, but it would then lose focus, so I had to force it to be focused after a timeout of 0. But when the window regains focus, it automatically focuses the last input. That would kick off a focus of the blurred input, and you'd end up in an endless focus fight between inputs.

This only forces focus when you click, not from other focus events.