### PR TITLE
Fix empty type choices

### DIFF
--- a/demo/examples/single-line-string.js
+++ b/demo/examples/single-line-string.js
@@ -3,7 +3,6 @@ const fields = [
     label: 'single line string',
     type: 'single-line-string',
     key: 'single-line-string',
-    autoFocus: true,
     placeholder: 'type something...',
     autoComplete: 'on'
   },

--- a/lib/components/helpers/field-template-choices.js
+++ b/lib/components/helpers/field-template-choices.js
@@ -7,7 +7,6 @@ Give a list of choices of item types to create as children of an field.
 'use strict';
 
 var React = require('react');
-var _ = require('lodash');
 var cx = require('classnames');
 
 module.exports = React.createClass({
@@ -31,7 +30,7 @@ module.exports = React.createClass({
 
     var fieldTemplates = config.fieldItemFieldTemplates(field);
 
-    return _.isEmpty(fieldTemplates) ? null : (
+    return (fieldTemplates.length < 2) ? null : (
       <select
         className={cx(this.props.classes)}
         value={this.fieldTemplateIndex}


### PR DESCRIPTION
@neilff Looks like there was a little bug introduced by your recent PR. This:

![](https://cdn.zapier.com/storage/photos/2015750e53a79d5ac7765e4cf3332654.png)

is supposed to be:

![](https://cdn.zapier.com/storage/photos/65d715e7eddfd61a36d5509a6f205b8e.png)

Check out the diff. You had changed a `(fieldTemplates.length > 1)` check into `_.isEmpty(fieldTemplates)`, so for the case where there was one field template, it was showing a type choice when it shouldn't.

Also, I didn't notice in that PR that you were requiring `lodash`. Note that Formatic uses its own "undash" to avoid requiring lodash as a dep. Lodash is only a dev dependency, so it didn't make it into any build but would be broken for anybody that uses Formatic but not lodash.

I also removed an autofocus on the single-line-string field that was causing the demo to scroll directly to that field.