### PR TITLE
Fix choice with action jsx

### DIFF
--- a/lib/components/helpers/choices.js
+++ b/lib/components/helpers/choices.js
@@ -508,13 +508,13 @@ module.exports = React.createClass({
                     <a href={'JavaScript' + ':'} onClick={this.onChoiceAction.bind(this, choice)}>
                       <span className={labelClasses}>
                         {choice.label || this.props.config.actionChoiceLabel(choice.action)}
-                        {
-                          this.props.config.createElement('choice-action-sample', {
-                            action: choice.action,
-                            choice: choice
-                          })
-                        }
                       </span>
+                      {
+                        this.props.config.createElement('choice-action-sample', {
+                          action: choice.action,
+                          choice: choice
+                        })
+                      }
                     </a>
                   );
 


### PR DESCRIPTION
This commit #http://localhost:8000/app/editor/2078/nodes/2079/fields inadvertently changed things when converting to JSX. What was two sibling `span` elements got nested. This PR reverts that.