### PR TITLE
Protect humanize from choking

### DIFF
--- a/__tests__/plugins.js
+++ b/__tests__/plugins.js
@@ -36,4 +36,30 @@ describe('plugins', function() {
     expect(config.isEmptyObject({})).toEqual(true);
     expect(config.isEmptyObject('foo')).toEqual(false);
   });
+
+  describe('humanize', function() {
+
+    it('doesn’t choke on numbers', function () {
+
+      var config = Formatic.createConfig();
+
+      expect(config.humanize(123)).toEqual('123');
+    });
+
+    it('doesn’t choke on falsey values', function () {
+
+      var config = Formatic.createConfig();
+
+      expect(config.humanize(undefined)).toEqual('');
+    });
+
+    it('doesn’t choke on string values', function () {
+
+      var config = Formatic.createConfig();
+
+      expect(config.humanize('string')).toEqual('String');
+    });
+
+  });
+
 });

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -989,8 +989,8 @@ module.exports = function (config) {
     },
 
     // Convert a key to a nice human-readable version.
-    humanize: function(property) {
-      property = property.replace(/\{\{/g, '');
+    humanize: function(property = '') {
+      property = String(property).replace(/\{\{/g, '');
       property = property.replace(/\}\}/g, '');
       return property.replace(/_/g, ' ')
       .replace(/(\w+)/g, function(match) {


### PR DESCRIPTION
This PR can knock out a couple different reported issues -- yay!
Fixes: [#11330](https://github.com/zapier/zapier/issues/11330) and  [#11418](https://github.com/zapier/zapier/issues/11418)

Looks like in some cases, a falsey or non-string type value is sent to `humanize`, which throws an error. These changes ensure the `property` is a string, and provide a default value for falsey input.

@jdeal Would you take a 👀 at this when you get a chance? You might know edge cases here
