### PR TITLE
Use es6 imports/exports

### DIFF
--- a/__tests__/actions.js
+++ b/__tests__/actions.js
@@ -1,11 +1,11 @@
 /*global describe, it, expect*/
 'use strict';
 
-describe('actions', function() {
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
 
-  var React = require('react');
-  var ReactDOM = require('react-dom');
-  var TestUtils = require('react-addons-test-utils');
+describe('actions', function() {
 
   var mounted = function (element) {
     var rendered = TestUtils.renderIntoDocument(element);

--- a/__tests__/actions.js
+++ b/__tests__/actions.js
@@ -5,14 +5,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
+import Formatic from '../lib/formatic';
+
 describe('actions', function() {
 
   var mounted = function (element) {
     var rendered = TestUtils.renderIntoDocument(element);
     return rendered;
   };
-
-  var Formatic = require('../lib/formatic');
 
   var formaticConfig = Formatic.createConfig(
     Formatic.plugins.elementClasses,

--- a/__tests__/components/fields/assoc-list.js
+++ b/__tests__/components/fields/assoc-list.js
@@ -1,10 +1,9 @@
 /*global describe, it, expect*/
 'use strict';
 
-const React = require('react');
-const TestUtils = require('react-addons-test-utils');
-
-const Formatic = require('../../../lib/formatic');
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import Formatic from '../../../lib/formatic';
 
 const renderedKeys = doc => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'input');

--- a/__tests__/components/fields/object.js
+++ b/__tests__/components/fields/object.js
@@ -157,8 +157,6 @@ describe('object field', () => {
     renderToNode(value);
     const formatic = renderToNode(value);
 
-    const ObjectClass = require('../../../lib/components/fields/object');
-
     const object = TestUtils.findRenderedComponentWithType(formatic, ObjectClass);
 
     expect(object.state).toEqual({

--- a/__tests__/components/fields/object.js
+++ b/__tests__/components/fields/object.js
@@ -5,6 +5,7 @@ import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import ReactDOM from 'react-dom';
 import Formatic from '../../../lib/formatic';
+import ObjectClass from '../../../lib/components/fields/object';
 
 const renderedKeys = doc => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'input');
@@ -118,8 +119,6 @@ describe('object field', () => {
 
     renderToNode(value);
     const formatic = renderToNode(value);
-
-    const ObjectClass = require('../../../lib/components/fields/object');
 
     const object = TestUtils.findRenderedComponentWithType(formatic, ObjectClass);
 

--- a/__tests__/components/fields/object.js
+++ b/__tests__/components/fields/object.js
@@ -1,11 +1,10 @@
 /*global describe, it, beforeEach, expect*/
 'use strict';
 
-const React = require('react');
-const TestUtils = require('react-addons-test-utils');
-const ReactDOM = require('react-dom');
-
-const Formatic = require('../../../lib/formatic');
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import ReactDOM from 'react-dom';
+import Formatic from '../../../lib/formatic';
 
 const renderedKeys = doc => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'input');

--- a/__tests__/components/helpers/tag-translator-test.js
+++ b/__tests__/components/helpers/tag-translator-test.js
@@ -1,8 +1,10 @@
 'use strict';
+
 /* global describe it expect */
 
-var TagTranslator = require('../../../lib/components/helpers/tag-translator');
-const Formatic = require('../../../lib/formatic');
+import TagTranslator from '../../../lib/components/helpers/tag-translator';
+
+import Formatic from '../../../lib/formatic';
 
 describe('editor-util', function () {
   var replaceChoices = [

--- a/__tests__/plugins.js
+++ b/__tests__/plugins.js
@@ -1,9 +1,9 @@
 /*global describe, it, expect*/
 'use strict';
 
-describe('plugins', function() {
+import Formatic from '../lib/formatic';
 
-  var Formatic = require('../lib/formatic');
+describe('plugins', function() {
 
   it('can create a new default configuration', function () {
 

--- a/__tests__/types.js
+++ b/__tests__/types.js
@@ -1,6 +1,12 @@
 /*global describe, it, expect*/
 'use strict';
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+import _ from 'lodash';
+import Formatic from '../lib/formatic';
+
 var printTree = function (node, indent) {
   indent = indent || '';
   if (node && node.childNodes) {
@@ -14,17 +20,10 @@ var printTree = function (node, indent) {
 
 describe('types and value changes', function() {
 
-  var React = require('react');
-  var ReactDOM = require('react-dom');
-  var TestUtils = require('react-addons-test-utils');
-  var _ = require('lodash');
-
   var mounted = function (element) {
     var rendered = TestUtils.renderIntoDocument(element);
     return rendered;
   };
-
-  var Formatic = require('../lib/formatic');
 
   var formaticConfig = Formatic.createConfig(
     Formatic.plugins.elementClasses,

--- a/__tests__/undash.js
+++ b/__tests__/undash.js
@@ -1,9 +1,9 @@
 /*global describe, it, expect*/
 'use strict';
 
-describe('utils', () => {
+import _ from '../lib/undash';
 
-  var _ = require('../lib/undash');
+describe('utils', () => {
 
   it('should flatten', () => {
 

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,9 +1,9 @@
 /*global describe, it, expect*/
 'use strict';
 
-describe('utils', function() {
+import utils from '../lib/utils';
 
-  var utils = require('../lib/utils');
+describe('utils', function() {
 
   it('should deep copy primitives', function () {
 

--- a/__tests__/validation.js
+++ b/__tests__/validation.js
@@ -1,9 +1,9 @@
 /*global describe, it, expect*/
 'use strict';
 
-describe('types and value changes', function() {
+import Formatic from '../lib/formatic';
 
-  var Formatic = require('../lib/formatic');
+describe('types and value changes', function() {
 
   var config = Formatic.createConfig();
 

--- a/lib/components/fields/array.js
+++ b/lib/components/fields/array.js
@@ -9,11 +9,13 @@ Render a field to edit array values.
 import React from 'react';
 import cx from 'classnames';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'Array',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   nextLookupId: 0,
 

--- a/lib/components/fields/array.js
+++ b/lib/components/fields/array.js
@@ -9,7 +9,7 @@ Render a field to edit array values.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Array',
 

--- a/lib/components/fields/array.js
+++ b/lib/components/fields/array.js
@@ -6,8 +6,8 @@ Render a field to edit array values.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/assoc-list.js
+++ b/lib/components/fields/assoc-list.js
@@ -10,6 +10,8 @@ import React from 'react';
 import cx from 'classnames';
 import update from 'react-addons-update';
 
+import FieldMixin from '../../mixins/field';
+
 const keyCountsByKey = (assocList) => {
   const counts = {};
   assocList.forEach((row) => {
@@ -25,7 +27,7 @@ export default React.createClass({
 
   displayName: 'AssocList',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   nextLookupId: 0,
 

--- a/lib/components/fields/assoc-list.js
+++ b/lib/components/fields/assoc-list.js
@@ -6,9 +6,9 @@ Render a field to edit a array of key / value objects, where duplicate keys are 
 
 'use strict';
 
-const React = require('react');
-const cx = require('classnames');
-const update = require('react-addons-update');
+import React from 'react';
+import cx from 'classnames';
+import update from 'react-addons-update';
 
 const keyCountsByKey = (assocList) => {
   const counts = {};

--- a/lib/components/fields/assoc-list.js
+++ b/lib/components/fields/assoc-list.js
@@ -21,7 +21,7 @@ const keyCountsByKey = (assocList) => {
   return counts;
 };
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'AssocList',
 

--- a/lib/components/fields/boolean.js
+++ b/lib/components/fields/boolean.js
@@ -8,11 +8,13 @@ Render a dropdown to handle yes/no boolean values.
 
 import React from 'react';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'Boolean',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChange: function (newValue) {
     this.onChangeValue(newValue);

--- a/lib/components/fields/boolean.js
+++ b/lib/components/fields/boolean.js
@@ -8,7 +8,7 @@ Render a dropdown to handle yes/no boolean values.
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Boolean',
 

--- a/lib/components/fields/boolean.js
+++ b/lib/components/fields/boolean.js
@@ -6,7 +6,7 @@ Render a dropdown to handle yes/no boolean values.
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/checkbox-array.js
+++ b/lib/components/fields/checkbox-array.js
@@ -11,7 +11,7 @@ import React from 'react';
 import _ from '../../undash';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'CheckboxArray',
 

--- a/lib/components/fields/checkbox-array.js
+++ b/lib/components/fields/checkbox-array.js
@@ -8,14 +8,16 @@ enumerated values to an array.
 'use strict';
 
 import React from 'react';
-import _ from '../../undash';
 import cx from 'classnames';
+
+import _ from '../../undash';
+import FieldMixin from '../../mixins/field';
 
 export default React.createClass({
 
   displayName: 'CheckboxArray',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   getInitialState: function () {
     return {

--- a/lib/components/fields/checkbox-array.js
+++ b/lib/components/fields/checkbox-array.js
@@ -7,9 +7,9 @@ enumerated values to an array.
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/checkbox-boolean.js
+++ b/lib/components/fields/checkbox-boolean.js
@@ -6,8 +6,8 @@ Render a field that can edit a boolean with a checkbox.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/checkbox-boolean.js
+++ b/lib/components/fields/checkbox-boolean.js
@@ -9,11 +9,13 @@ Render a field that can edit a boolean with a checkbox.
 import React from 'react';
 import cx from 'classnames';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'CheckboxBoolean',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChange: function (event) {
     this.onChangeValue(event.target.checked);

--- a/lib/components/fields/checkbox-boolean.js
+++ b/lib/components/fields/checkbox-boolean.js
@@ -9,7 +9,7 @@ Render a field that can edit a boolean with a checkbox.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'CheckboxBoolean',
 

--- a/lib/components/fields/code.js
+++ b/lib/components/fields/code.js
@@ -11,7 +11,7 @@ import cx from 'classnames';
 /*
   A very trimmed down field that uses CodeMirror for syntax highlighting *only*.
  */
-module.exports = React.createClass({
+export default React.createClass({
   displayName: 'Code',
 
   mixins: [require('../../mixins/field')],

--- a/lib/components/fields/code.js
+++ b/lib/components/fields/code.js
@@ -4,9 +4,10 @@
 /*eslint no-script-url:0 */
 
 import React from 'react';
+import cx from 'classnames';
 
 import _ from '../../undash';
-import cx from 'classnames';
+import FieldMixin from '../../mixins/field';
 
 /*
   A very trimmed down field that uses CodeMirror for syntax highlighting *only*.
@@ -14,7 +15,7 @@ import cx from 'classnames';
 export default React.createClass({
   displayName: 'Code',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   componentDidMount: function() {
     this.createCodeMirrorEditor();

--- a/lib/components/fields/code.js
+++ b/lib/components/fields/code.js
@@ -1,10 +1,12 @@
 'use strict';
+
 /* global CodeMirror */
 /*eslint no-script-url:0 */
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
+
+import _ from '../../undash';
+import cx from 'classnames';
 
 /*
   A very trimmed down field that uses CodeMirror for syntax highlighting *only*.

--- a/lib/components/fields/copy.js
+++ b/lib/components/fields/copy.js
@@ -9,11 +9,13 @@ Render non-editable html/text (think article copy).
 import React from 'react';
 import cx from 'classnames';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'Copy',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/fields/copy.js
+++ b/lib/components/fields/copy.js
@@ -9,7 +9,7 @@ Render non-editable html/text (think article copy).
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Copy',
 

--- a/lib/components/fields/copy.js
+++ b/lib/components/fields/copy.js
@@ -6,8 +6,8 @@ Render non-editable html/text (think article copy).
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/fields.js
+++ b/lib/components/fields/fields.js
@@ -10,7 +10,7 @@ import React from 'react';
 import _ from '../../undash';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Fields',
 

--- a/lib/components/fields/fields.js
+++ b/lib/components/fields/fields.js
@@ -6,9 +6,9 @@ Render a field to edit the values of an object with static properties.
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/fields.js
+++ b/lib/components/fields/fields.js
@@ -7,14 +7,16 @@ Render a field to edit the values of an object with static properties.
 'use strict';
 
 import React from 'react';
-import _ from '../../undash';
 import cx from 'classnames';
+
+import _ from '../../undash';
+import FieldMixin from '../../mixins/field';
 
 export default React.createClass({
 
   displayName: 'Fields',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChangeField: function (key, newValue, info) {
     if (!key) {

--- a/lib/components/fields/grouped-fields.js
+++ b/lib/components/fields/grouped-fields.js
@@ -7,8 +7,10 @@ Render a fields in groups. Grouped by field.groupKey property.
 'use strict';
 
 import React from 'react';
-import _ from '../../undash';
 import cx from 'classnames';
+
+import _ from '../../undash';
+import FieldMixin from '../../mixins/field';
 
 var groupFields = function (fields, humanize) {
   var groupedFields = [];
@@ -42,7 +44,7 @@ export default React.createClass({
 
   displayName: 'GroupedFields',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChangeField: function (key, newValue, info) {
     if (key) {

--- a/lib/components/fields/grouped-fields.js
+++ b/lib/components/fields/grouped-fields.js
@@ -38,7 +38,7 @@ var groupFields = function (fields, humanize) {
   return groupedFields;
 };
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'GroupedFields',
 

--- a/lib/components/fields/grouped-fields.js
+++ b/lib/components/fields/grouped-fields.js
@@ -6,9 +6,9 @@ Render a fields in groups. Grouped by field.groupKey property.
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
 
 var groupFields = function (fields, humanize) {
   var groupedFields = [];

--- a/lib/components/fields/json.js
+++ b/lib/components/fields/json.js
@@ -10,7 +10,7 @@ while the value is invalid, no external state changes will occur.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Json',
 

--- a/lib/components/fields/json.js
+++ b/lib/components/fields/json.js
@@ -10,11 +10,13 @@ while the value is invalid, no external state changes will occur.
 import React from 'react';
 import cx from 'classnames';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'Json',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   getDefaultProps: function () {
     return {

--- a/lib/components/fields/json.js
+++ b/lib/components/fields/json.js
@@ -7,8 +7,8 @@ while the value is invalid, no external state changes will occur.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/object.js
+++ b/lib/components/fields/object.js
@@ -24,7 +24,7 @@ const hasDuplicateKeys = (assocList) => {
   return hasDups;
 };
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Object',
 

--- a/lib/components/fields/object.js
+++ b/lib/components/fields/object.js
@@ -9,6 +9,8 @@ Render a field to edit an object with dynamic child fields.
 import React from 'react';
 import update from 'react-addons-update';
 
+import FieldMixin from '../../mixins/field';
+
 const hasDuplicateKeys = (assocList) => {
   let hasDups = false;
   const keys = {};
@@ -28,7 +30,7 @@ export default React.createClass({
 
   displayName: 'Object',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   getInitialState() {
     const config = this.props.config;

--- a/lib/components/fields/object.js
+++ b/lib/components/fields/object.js
@@ -6,8 +6,8 @@ Render a field to edit an object with dynamic child fields.
 
 'use strict';
 
-const React = require('react');
-const update = require('react-addons-update');
+import React from 'react';
+import update from 'react-addons-update';
 
 const hasDuplicateKeys = (assocList) => {
   let hasDups = false;

--- a/lib/components/fields/password.js
+++ b/lib/components/fields/password.js
@@ -9,11 +9,13 @@ Render a single line text input.
 import React from 'react';
 import cx from 'classnames';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'Password',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChange: function (event) {
     this.onChangeValue(event.target.value);

--- a/lib/components/fields/password.js
+++ b/lib/components/fields/password.js
@@ -9,7 +9,7 @@ Render a single line text input.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Password',
 

--- a/lib/components/fields/password.js
+++ b/lib/components/fields/password.js
@@ -6,8 +6,8 @@ Render a single line text input.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/pretty-boolean.js
+++ b/lib/components/fields/pretty-boolean.js
@@ -6,7 +6,7 @@ Render pretty boolean component with non-native drop-down
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/pretty-boolean.js
+++ b/lib/components/fields/pretty-boolean.js
@@ -8,7 +8,7 @@ Render pretty boolean component with non-native drop-down
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'PrettyBoolean',
 

--- a/lib/components/fields/pretty-boolean.js
+++ b/lib/components/fields/pretty-boolean.js
@@ -8,11 +8,13 @@ Render pretty boolean component with non-native drop-down
 
 import React from 'react';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'PrettyBoolean',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChange: function (newValue) {
     this.onChangeValue(newValue);

--- a/lib/components/fields/pretty-select.js
+++ b/lib/components/fields/pretty-select.js
@@ -9,7 +9,7 @@ select drop down and supports fancier renderings.
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'PrettySelect',
 

--- a/lib/components/fields/pretty-select.js
+++ b/lib/components/fields/pretty-select.js
@@ -9,11 +9,13 @@ select drop down and supports fancier renderings.
 
 import React from 'react';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'PrettySelect',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   getInitialState: function () {
     return {

--- a/lib/components/fields/pretty-select.js
+++ b/lib/components/fields/pretty-select.js
@@ -7,7 +7,7 @@ select drop down and supports fancier renderings.
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/pretty-text.js
+++ b/lib/components/fields/pretty-text.js
@@ -25,9 +25,13 @@ So good luck!
 'use strict';
 
 import React from 'react';
-import _ from '../../undash';
 import cx from 'classnames';
+
+import _ from '../../undash';
 import utils from '../../utils';
+import FieldMixin from '../../mixins/field';
+import UndoStackMixin from '../../mixins/undo-stack';
+import ResizeMixin from '../../mixins/resize';
 
 var noBreak = function (value) {
   return value.replace(/ /g, '\u00a0');
@@ -54,6 +58,7 @@ var positionInNode = function (position, node) {
       return true;
     }
   }
+  return undefined;
 };
 
 // Wrap a text value so it has a type. For parsing text with tags.
@@ -72,15 +77,15 @@ var parseTextWithTags = function (value) {
   var frontPart = [];
   if (parts[0] !== '') {
     frontPart = [
-    textPart(parts[0])
+      textPart(parts[0])
     ];
   }
   parts = frontPart.concat(
     parts.slice(1).map(function (part) {
       if (part.indexOf('}}') >= 0) {
         return [
-        textPart(part.substring(0, part.indexOf('}}')), 'tag'),
-        textPart(part.substring(part.indexOf('}}') + 2))
+          textPart(part.substring(0, part.indexOf('}}')), 'tag'),
+          textPart(part.substring(part.indexOf('}}') + 2))
         ];
       } else {
         return textPart('{{' + part, 'text');
@@ -95,7 +100,11 @@ export default React.createClass({
 
   displayName: 'TaggedText',
 
-  mixins: [require('../../mixins/field'), require('../../mixins/undo-stack'), require('../../mixins/resize')],
+  mixins: [
+    FieldMixin,
+    UndoStackMixin,
+    ResizeMixin
+  ],
 
   //
   // getDefaultProps: function () {

--- a/lib/components/fields/pretty-text.js
+++ b/lib/components/fields/pretty-text.js
@@ -24,11 +24,10 @@ So good luck!
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
-
-var utils = require('../../utils');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
+import utils from '../../utils';
 
 var noBreak = function (value) {
   return value.replace(/ /g, '\u00a0');

--- a/lib/components/fields/pretty-text.js
+++ b/lib/components/fields/pretty-text.js
@@ -91,7 +91,7 @@ var parseTextWithTags = function (value) {
 };
 
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'TaggedText',
 

--- a/lib/components/fields/pretty-text2.js
+++ b/lib/components/fields/pretty-text2.js
@@ -7,7 +7,7 @@ import React from 'react';
 /*
    Wraps a PrettyTextInput to be a stand alone field.
  */
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'PrettyText',
 

--- a/lib/components/fields/pretty-text2.js
+++ b/lib/components/fields/pretty-text2.js
@@ -1,7 +1,8 @@
 'use strict';
+
 /*eslint no-script-url:0 */
 
-var React = require('react');
+import React from 'react';
 
 /*
    Wraps a PrettyTextInput to be a stand alone field.

--- a/lib/components/fields/pretty-text2.js
+++ b/lib/components/fields/pretty-text2.js
@@ -4,6 +4,8 @@
 
 import React from 'react';
 
+import FieldMixin from '../../mixins/field';
+
 /*
    Wraps a PrettyTextInput to be a stand alone field.
  */
@@ -11,7 +13,7 @@ export default React.createClass({
 
   displayName: 'PrettyText',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   render: function() {
     return this.renderWithConfig();

--- a/lib/components/fields/select.js
+++ b/lib/components/fields/select.js
@@ -8,7 +8,7 @@ boolean values, but it _should_ work for other values.
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/select.js
+++ b/lib/components/fields/select.js
@@ -10,7 +10,7 @@ boolean values, but it _should_ work for other values.
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Select',
 

--- a/lib/components/fields/select.js
+++ b/lib/components/fields/select.js
@@ -10,11 +10,13 @@ boolean values, but it _should_ work for other values.
 
 import React from 'react';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'Select',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   getInitialState: function () {
     return {

--- a/lib/components/fields/single-line-string.js
+++ b/lib/components/fields/single-line-string.js
@@ -9,11 +9,13 @@ Render a single line text input.
 import React from 'react';
 import cx from 'classnames';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'SingleLineString',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChange: function (event) {
     this.onChangeValue(event.target.value);

--- a/lib/components/fields/single-line-string.js
+++ b/lib/components/fields/single-line-string.js
@@ -9,7 +9,7 @@ Render a single line text input.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'SingleLineString',
 

--- a/lib/components/fields/single-line-string.js
+++ b/lib/components/fields/single-line-string.js
@@ -6,8 +6,8 @@ Render a single line text input.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/string.js
+++ b/lib/components/fields/string.js
@@ -9,11 +9,13 @@ Render a field that can edit a string value.
 import React from 'react';
 import cx from 'classnames';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'String',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   onChange: function (event) {
     this.onChangeValue(event.target.value);

--- a/lib/components/fields/string.js
+++ b/lib/components/fields/string.js
@@ -9,7 +9,7 @@ Render a field that can edit a string value.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'String',
 

--- a/lib/components/fields/string.js
+++ b/lib/components/fields/string.js
@@ -6,8 +6,8 @@ Render a field that can edit a string value.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/fields/unknown.js
+++ b/lib/components/fields/unknown.js
@@ -8,7 +8,7 @@ Render a field with an unknown type.
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Unknown',
 

--- a/lib/components/fields/unknown.js
+++ b/lib/components/fields/unknown.js
@@ -8,11 +8,13 @@ Render a field with an unknown type.
 
 import React from 'react';
 
+import FieldMixin from '../../mixins/field';
+
 export default React.createClass({
 
   displayName: 'Unknown',
 
-  mixins: [require('../../mixins/field')],
+  mixins: [FieldMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/fields/unknown.js
+++ b/lib/components/fields/unknown.js
@@ -6,7 +6,7 @@ Render a field with an unknown type.
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/add-item.js
+++ b/lib/components/helpers/add-item.js
@@ -6,8 +6,8 @@ The add button to append an item to a field.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/add-item.js
+++ b/lib/components/helpers/add-item.js
@@ -9,11 +9,13 @@ The add button to append an item to a field.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'AddItem',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getDefaultProps: function () {
     return {

--- a/lib/components/helpers/add-item.js
+++ b/lib/components/helpers/add-item.js
@@ -9,7 +9,7 @@ The add button to append an item to a field.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'AddItem',
 

--- a/lib/components/helpers/array-control.js
+++ b/lib/components/helpers/array-control.js
@@ -9,11 +9,13 @@ Render the item type choices and the add button for an array.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'ArrayControl',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getInitialState: function () {
     return {

--- a/lib/components/helpers/array-control.js
+++ b/lib/components/helpers/array-control.js
@@ -6,8 +6,8 @@ Render the item type choices and the add button for an array.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/array-control.js
+++ b/lib/components/helpers/array-control.js
@@ -9,7 +9,7 @@ Render the item type choices and the add button for an array.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ArrayControl',
 

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -9,7 +9,7 @@ Render the remove and move buttons for an array field.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ArrayItemControl',
 

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -6,8 +6,8 @@ Render the remove and move buttons for an array field.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -9,11 +9,13 @@ Render the remove and move buttons for an array field.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'ArrayItemControl',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onMoveBack: function () {
     this.props.onMove(this.props.index, this.props.index - 1);

--- a/lib/components/helpers/array-item-value.js
+++ b/lib/components/helpers/array-item-value.js
@@ -6,8 +6,8 @@ Render the value of an array item.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/array-item-value.js
+++ b/lib/components/helpers/array-item-value.js
@@ -9,11 +9,13 @@ Render the value of an array item.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'ArrayItemValue',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onChangeField: function (newValue, info) {
     this.props.onChange(this.props.index, newValue, info);

--- a/lib/components/helpers/array-item-value.js
+++ b/lib/components/helpers/array-item-value.js
@@ -9,7 +9,7 @@ Render the value of an array item.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ArrayItemValue',
 

--- a/lib/components/helpers/array-item.js
+++ b/lib/components/helpers/array-item.js
@@ -10,7 +10,7 @@ import React from 'react';
 import cx from 'classnames';
 import _ from '../../undash';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ArrayItem',
 

--- a/lib/components/helpers/array-item.js
+++ b/lib/components/helpers/array-item.js
@@ -10,11 +10,13 @@ import React from 'react';
 import cx from 'classnames';
 import _ from '../../undash';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'ArrayItem',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getInitialState: function () {
     return {

--- a/lib/components/helpers/array-item.js
+++ b/lib/components/helpers/array-item.js
@@ -6,9 +6,9 @@ Render an array item.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
-var _ = require('../../undash');
+import React from 'react';
+import cx from 'classnames';
+import _ from '../../undash';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/assoc-list-control.js
+++ b/lib/components/helpers/assoc-list-control.js
@@ -9,7 +9,7 @@ Render the item type choices and the add button.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ObjectControl',
 

--- a/lib/components/helpers/assoc-list-control.js
+++ b/lib/components/helpers/assoc-list-control.js
@@ -6,8 +6,8 @@ Render the item type choices and the add button.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/assoc-list-control.js
+++ b/lib/components/helpers/assoc-list-control.js
@@ -9,11 +9,13 @@ Render the item type choices and the add button.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'ObjectControl',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getInitialState: function () {
     return {

--- a/lib/components/helpers/assoc-list-item-control.js
+++ b/lib/components/helpers/assoc-list-item-control.js
@@ -9,11 +9,13 @@ Render the remove buttons for an object item.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'AssocListItemControl',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onRemove: function () {
     this.props.onRemove(this.props.index);

--- a/lib/components/helpers/assoc-list-item-control.js
+++ b/lib/components/helpers/assoc-list-item-control.js
@@ -6,8 +6,8 @@ Render the remove buttons for an object item.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/assoc-list-item-control.js
+++ b/lib/components/helpers/assoc-list-item-control.js
@@ -9,7 +9,7 @@ Render the remove buttons for an object item.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'AssocListItemControl',
 

--- a/lib/components/helpers/assoc-list-item-key.js
+++ b/lib/components/helpers/assoc-list-item-key.js
@@ -10,7 +10,7 @@ import React from 'react';
 import cx from 'classnames';
 import _ from '../../undash';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'AssocListItemKey',
 

--- a/lib/components/helpers/assoc-list-item-key.js
+++ b/lib/components/helpers/assoc-list-item-key.js
@@ -10,11 +10,13 @@ import React from 'react';
 import cx from 'classnames';
 import _ from '../../undash';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'AssocListItemKey',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onChange: function (event) {
     this.props.onChange(event.target.value);

--- a/lib/components/helpers/assoc-list-item-key.js
+++ b/lib/components/helpers/assoc-list-item-key.js
@@ -6,9 +6,9 @@ Render an object item key editor.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
-var _ = require('../../undash');
+import React from 'react';
+import cx from 'classnames';
+import _ from '../../undash';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/assoc-list-item-value.js
+++ b/lib/components/helpers/assoc-list-item-value.js
@@ -6,8 +6,8 @@ Render the value of an object item.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/assoc-list-item-value.js
+++ b/lib/components/helpers/assoc-list-item-value.js
@@ -9,11 +9,13 @@ Render the value of an object item.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'AssocListItemValue',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onChangeField: function (newValue, info) {
     this.props.onChange(this.props.index, newValue, info);

--- a/lib/components/helpers/assoc-list-item-value.js
+++ b/lib/components/helpers/assoc-list-item-value.js
@@ -9,7 +9,7 @@ Render the value of an object item.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'AssocListItemValue',
 

--- a/lib/components/helpers/assoc-list-item.js
+++ b/lib/components/helpers/assoc-list-item.js
@@ -9,7 +9,7 @@ Render an object item.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'AssocListItem',
 

--- a/lib/components/helpers/assoc-list-item.js
+++ b/lib/components/helpers/assoc-list-item.js
@@ -6,8 +6,8 @@ Render an object item.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/assoc-list-item.js
+++ b/lib/components/helpers/assoc-list-item.js
@@ -9,11 +9,13 @@ Render an object item.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'AssocListItem',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onChangeKey: function (newKey) {
     this.props.onChangeKey(this.props.index, newKey);

--- a/lib/components/helpers/choice-section-header.js
+++ b/lib/components/helpers/choice-section-header.js
@@ -6,8 +6,8 @@ Render section header in choices dropdown
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/choice-section-header.js
+++ b/lib/components/helpers/choice-section-header.js
@@ -9,11 +9,13 @@ Render section header in choices dropdown
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'ChoiceSectionHeader',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/choice-section-header.js
+++ b/lib/components/helpers/choice-section-header.js
@@ -9,7 +9,7 @@ Render section header in choices dropdown
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ChoiceSectionHeader',
 

--- a/lib/components/helpers/choice.js
+++ b/lib/components/helpers/choice.js
@@ -8,11 +8,13 @@ A single choice in a list of choices.
 
 import React from 'react';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'Choice',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render() {
     return this.renderWithConfig();

--- a/lib/components/helpers/choice.js
+++ b/lib/components/helpers/choice.js
@@ -8,7 +8,7 @@ A single choice in a list of choices.
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Choice',
 

--- a/lib/components/helpers/choice.js
+++ b/lib/components/helpers/choice.js
@@ -6,7 +6,7 @@ A single choice in a list of choices.
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/choices-dropdown.js
+++ b/lib/components/helpers/choices-dropdown.js
@@ -12,7 +12,7 @@ import _ from '../../undash';
    TODO: Implemented via Bootstrap dropdown for now but we
    want to remove that dependency.
  */
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ChoicesDropdown',
 

--- a/lib/components/helpers/choices-dropdown.js
+++ b/lib/components/helpers/choices-dropdown.js
@@ -1,7 +1,9 @@
 'use strict';
 
 import React from 'react';
+
 import _ from '../../undash';
+import HelperMixin from '../../mixins/helper';
 
 /*
    Choices drop down component for picking pretty text tags.
@@ -16,7 +18,7 @@ export default React.createClass({
 
   displayName: 'ChoicesDropdown',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   propTypes: {
     handleSelection: React.PropTypes.func.isRequired

--- a/lib/components/helpers/choices-dropdown.js
+++ b/lib/components/helpers/choices-dropdown.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
+import React from 'react';
+import _ from '../../undash';
 
 /*
    Choices drop down component for picking pretty text tags.

--- a/lib/components/helpers/choices-item.js
+++ b/lib/components/helpers/choices-item.js
@@ -6,10 +6,9 @@
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
-
-var _ = require('../../undash');
+import React from 'react';
+import cx from 'classnames';
+import _ from '../../undash';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/choices-item.js
+++ b/lib/components/helpers/choices-item.js
@@ -10,7 +10,7 @@ import React from 'react';
 import cx from 'classnames';
 import _ from '../../undash';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ChoicesItem',
 

--- a/lib/components/helpers/choices-item.js
+++ b/lib/components/helpers/choices-item.js
@@ -8,13 +8,15 @@
 
 import React from 'react';
 import cx from 'classnames';
+
 import _ from '../../undash';
+import HelperMixin from '../../mixins/helper';
 
 export default React.createClass({
 
   displayName: 'ChoicesItem',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/choices-search.js
+++ b/lib/components/helpers/choices-search.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/choices-search.js
+++ b/lib/components/helpers/choices-search.js
@@ -8,11 +8,13 @@
 
 import React from 'react';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'ChoicesSearch',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   focus() {
     this.refs.input.focus();

--- a/lib/components/helpers/choices-search.js
+++ b/lib/components/helpers/choices-search.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'ChoicesSearch',
 

--- a/lib/components/helpers/choices.js
+++ b/lib/components/helpers/choices.js
@@ -8,9 +8,12 @@ Render customized (non-native) dropdown choices.
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import _ from '../../undash';
 import ScrollLock from 'react-scroll-lock';
+
+import _ from '../../undash';
 import {keyCodes, scrollIntoContainerView} from '../../utils';
+import HelperMixin from '../../mixins/helper';
+import ClickOutsideMixin from '../../mixins/click-outside';
 
 var magicChoiceRe = /^\/\/\/[^\/]+\/\/\/$/;
 
@@ -48,8 +51,8 @@ export default React.createClass({
   displayName: 'Choices',
 
   mixins: [
-    require('../../mixins/helper'),
-    require('../../mixins/click-outside'),
+    HelperMixin,
+    ClickOutsideMixin,
     ScrollLock
   ],
 

--- a/lib/components/helpers/choices.js
+++ b/lib/components/helpers/choices.js
@@ -43,7 +43,7 @@ const getInitiallyOpenSections = (choices = []) => (
     .map((choice) => choice.sectionKey)
 );
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Choices',
 

--- a/lib/components/helpers/choices.js
+++ b/lib/components/helpers/choices.js
@@ -6,12 +6,11 @@ Render customized (non-native) dropdown choices.
 
 'use strict';
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var _ = require('../../undash');
-var ScrollLock = require('react-scroll-lock');
-
-var { keyCodes, scrollIntoContainerView } = require('../../utils');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import _ from '../../undash';
+import ScrollLock from 'react-scroll-lock';
+import {keyCodes, scrollIntoContainerView} from '../../utils';
 
 var magicChoiceRe = /^\/\/\/[^\/]+\/\/\/$/;
 

--- a/lib/components/helpers/field-template-choices.js
+++ b/lib/components/helpers/field-template-choices.js
@@ -6,8 +6,8 @@ Give a list of choices of item types to create as children of an field.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/field-template-choices.js
+++ b/lib/components/helpers/field-template-choices.js
@@ -9,11 +9,13 @@ Give a list of choices of item types to create as children of an field.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'FieldTemplateChoices',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onChange: function (event) {
     this.props.onSelect(parseInt(event.target.value));

--- a/lib/components/helpers/field-template-choices.js
+++ b/lib/components/helpers/field-template-choices.js
@@ -9,7 +9,7 @@ Give a list of choices of item types to create as children of an field.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'FieldTemplateChoices',
 

--- a/lib/components/helpers/field.js
+++ b/lib/components/helpers/field.js
@@ -10,11 +10,13 @@ import React from 'react';
 import _ from '../../undash';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'Field',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getInitialState: function () {
     return {

--- a/lib/components/helpers/field.js
+++ b/lib/components/helpers/field.js
@@ -6,9 +6,9 @@ Used by any fields to put the label and help text around the field.
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/field.js
+++ b/lib/components/helpers/field.js
@@ -10,7 +10,7 @@ import React from 'react';
 import _ from '../../undash';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Field',
 

--- a/lib/components/helpers/help.js
+++ b/lib/components/helpers/help.js
@@ -6,8 +6,8 @@ Just the help text block.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/help.js
+++ b/lib/components/helpers/help.js
@@ -9,7 +9,7 @@ Just the help text block.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Help',
 

--- a/lib/components/helpers/help.js
+++ b/lib/components/helpers/help.js
@@ -9,11 +9,13 @@ Just the help text block.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'Help',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/insert-button.js
+++ b/lib/components/helpers/insert-button.js
@@ -9,6 +9,8 @@
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'InsertButton',
@@ -17,7 +19,7 @@ export default React.createClass({
     onClick: React.PropTypes.func.isRequired
   },
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/insert-button.js
+++ b/lib/components/helpers/insert-button.js
@@ -6,8 +6,8 @@
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/insert-button.js
+++ b/lib/components/helpers/insert-button.js
@@ -9,7 +9,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'InsertButton',
 

--- a/lib/components/helpers/label.js
+++ b/lib/components/helpers/label.js
@@ -6,8 +6,8 @@ Just the label for a field.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/label.js
+++ b/lib/components/helpers/label.js
@@ -9,11 +9,13 @@ Just the label for a field.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'Label',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/label.js
+++ b/lib/components/helpers/label.js
@@ -9,7 +9,7 @@ Just the label for a field.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Label',
 

--- a/lib/components/helpers/loading-choice.js
+++ b/lib/components/helpers/loading-choice.js
@@ -2,11 +2,13 @@
 
 import React from 'react';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'LoadingChoice',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/loading-choice.js
+++ b/lib/components/helpers/loading-choice.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'LoadingChoice',
 

--- a/lib/components/helpers/loading-choice.js
+++ b/lib/components/helpers/loading-choice.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/loading-choices.js
+++ b/lib/components/helpers/loading-choices.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/loading-choices.js
+++ b/lib/components/helpers/loading-choices.js
@@ -2,11 +2,13 @@
 
 import React from 'react';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'LoadingChoices',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/loading-choices.js
+++ b/lib/components/helpers/loading-choices.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'LoadingChoices',
 

--- a/lib/components/helpers/move-item-back.js
+++ b/lib/components/helpers/move-item-back.js
@@ -6,8 +6,8 @@ Button to move an item backwards in list.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/move-item-back.js
+++ b/lib/components/helpers/move-item-back.js
@@ -9,11 +9,13 @@ Button to move an item backwards in list.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'MoveItemBack',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getDefaultProps: function () {
     return {

--- a/lib/components/helpers/move-item-back.js
+++ b/lib/components/helpers/move-item-back.js
@@ -9,7 +9,7 @@ Button to move an item backwards in list.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'MoveItemBack',
 

--- a/lib/components/helpers/move-item-forward.js
+++ b/lib/components/helpers/move-item-forward.js
@@ -9,7 +9,7 @@ Button to move an item forward in a list.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'MoveItemForward',
 

--- a/lib/components/helpers/move-item-forward.js
+++ b/lib/components/helpers/move-item-forward.js
@@ -6,8 +6,8 @@ Button to move an item forward in a list.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/move-item-forward.js
+++ b/lib/components/helpers/move-item-forward.js
@@ -9,11 +9,13 @@ Button to move an item forward in a list.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'MoveItemForward',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getDefaultProps: function () {
     return {

--- a/lib/components/helpers/pretty-select-input.js
+++ b/lib/components/helpers/pretty-select-input.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/pretty-select-input.js
+++ b/lib/components/helpers/pretty-select-input.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'PrettySelectInput',
 

--- a/lib/components/helpers/pretty-select-input.js
+++ b/lib/components/helpers/pretty-select-input.js
@@ -8,11 +8,13 @@
 
 import React from 'react';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'PrettySelectInput',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/pretty-select-value.js
+++ b/lib/components/helpers/pretty-select-value.js
@@ -11,13 +11,15 @@
 import React from 'react';
 import _ from '../../undash';
 import cx from 'classnames';
+
 import {keyCodes, focusRefNode} from '../../utils';
+import HelperMixin from '../../mixins/helper';
 
 export default React.createClass({
 
   displayName: 'SelectValue',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onChange: function (event) {
     var choiceValue = event.target.value;

--- a/lib/components/helpers/pretty-select-value.js
+++ b/lib/components/helpers/pretty-select-value.js
@@ -13,7 +13,7 @@ import _ from '../../undash';
 import cx from 'classnames';
 import {keyCodes, focusRefNode} from '../../utils';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'SelectValue',
 

--- a/lib/components/helpers/pretty-select-value.js
+++ b/lib/components/helpers/pretty-select-value.js
@@ -8,11 +8,10 @@
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
-
-var { keyCodes, focusRefNode } = require('../../utils');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
+import {keyCodes, focusRefNode} from '../../utils';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/pretty-tag.js
+++ b/lib/components/helpers/pretty-tag.js
@@ -10,7 +10,7 @@ import React from 'react';
 import _ from '../../undash';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'PrettyTag',
 

--- a/lib/components/helpers/pretty-tag.js
+++ b/lib/components/helpers/pretty-tag.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/pretty-tag.js
+++ b/lib/components/helpers/pretty-tag.js
@@ -7,8 +7,10 @@
 'use strict';
 
 import React from 'react';
-import _ from '../../undash';
 import cx from 'classnames';
+
+import _ from '../../undash';
+import HelperMixin from '../../mixins/helper';
 
 export default React.createClass({
 
@@ -19,7 +21,7 @@ export default React.createClass({
     classes: React.PropTypes.object
   },
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -28,7 +28,7 @@ var toString = function (value) {
    instantiated when the user moves the mouse into the edit area.
    Initially a read-only view using a simple div is shown.
  */
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'PrettyTextInput',
 

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -4,12 +4,13 @@
 /*eslint no-script-url:0 */
 
 import React from 'react';
-
 import ReactDOM from 'react-dom';
+import cx from 'classnames';
+
 import TagTranslator from './tag-translator';
 import _ from '../../undash';
-import cx from 'classnames';
 import {keyCodes} from '../../utils';
+import HelperMixin from '../../mixins/helper';
 
 var toString = function (value) {
   if (_.isUndefined(value) || _.isNull(value)) {
@@ -32,7 +33,7 @@ export default React.createClass({
 
   displayName: 'PrettyTextInput',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   componentDidMount: function() {
     this.createEditor();

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -1,14 +1,15 @@
 'use strict';
+
 /* global CodeMirror */
 /*eslint no-script-url:0 */
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var TagTranslator = require('./tag-translator');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
 
-var { keyCodes } = require('../../utils');
+import ReactDOM from 'react-dom';
+import TagTranslator from './tag-translator';
+import _ from '../../undash';
+import cx from 'classnames';
+import {keyCodes} from '../../utils';
 
 var toString = function (value) {
   if (_.isUndefined(value) || _.isNull(value)) {

--- a/lib/components/helpers/remove-item.js
+++ b/lib/components/helpers/remove-item.js
@@ -10,7 +10,7 @@ import React from 'react';
 import cx from 'classnames';
 import _ from '../../undash';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'RemoveItem',
 

--- a/lib/components/helpers/remove-item.js
+++ b/lib/components/helpers/remove-item.js
@@ -6,9 +6,9 @@ Remove an item.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
-var _ = require('../../undash');
+import React from 'react';
+import cx from 'classnames';
+import _ from '../../undash';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/remove-item.js
+++ b/lib/components/helpers/remove-item.js
@@ -8,13 +8,15 @@ Remove an item.
 
 import React from 'react';
 import cx from 'classnames';
+
 import _ from '../../undash';
+import HelperMixin from '../../mixins/helper';
 
 export default React.createClass({
 
   displayName: 'RemoveItem',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   getDefaultProps: function () {
     return {

--- a/lib/components/helpers/sample.js
+++ b/lib/components/helpers/sample.js
@@ -9,7 +9,7 @@ Just the help text block.
 import React from 'react';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Sample',
 

--- a/lib/components/helpers/sample.js
+++ b/lib/components/helpers/sample.js
@@ -6,8 +6,8 @@ Just the help text block.
 
 'use strict';
 
-var React = require('react');
-var cx = require('classnames');
+import React from 'react';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/sample.js
+++ b/lib/components/helpers/sample.js
@@ -9,11 +9,13 @@ Just the help text block.
 import React from 'react';
 import cx from 'classnames';
 
+import HelperMixin from '../../mixins/helper';
+
 export default React.createClass({
 
   displayName: 'Sample',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   render: function () {
     return this.renderWithConfig();

--- a/lib/components/helpers/select-value.js
+++ b/lib/components/helpers/select-value.js
@@ -8,14 +8,16 @@ type.
 'use strict';
 
 import React from 'react';
-import _ from '../../undash';
 import cx from 'classnames';
+
+import _ from '../../undash';
+import HelperMixin from '../../mixins/helper';
 
 export default React.createClass({
 
   displayName: 'SelectValue',
 
-  mixins: [require('../../mixins/helper')],
+  mixins: [HelperMixin],
 
   onChange: function (event) {
     var choiceValue = event.target.value;

--- a/lib/components/helpers/select-value.js
+++ b/lib/components/helpers/select-value.js
@@ -7,9 +7,9 @@ type.
 
 'use strict';
 
-var React = require('react');
-var _ = require('../../undash');
-var cx = require('classnames');
+import React from 'react';
+import _ from '../../undash';
+import cx from 'classnames';
 
 module.exports = React.createClass({
 

--- a/lib/components/helpers/select-value.js
+++ b/lib/components/helpers/select-value.js
@@ -11,7 +11,7 @@ import React from 'react';
 import _ from '../../undash';
 import cx from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'SelectValue',
 

--- a/lib/components/helpers/tag-translator.js
+++ b/lib/components/helpers/tag-translator.js
@@ -76,4 +76,4 @@ const TagTranslator = (replaceChoices, humanize) => {
   };
 };
 
-module.exports = TagTranslator;
+export default TagTranslator;

--- a/lib/components/helpers/tag-translator.js
+++ b/lib/components/helpers/tag-translator.js
@@ -1,5 +1,5 @@
 'use strict';
-var _ = require('../../undash');
+import _ from '../../undash';
 
 const buildChoicesMap = (replaceChoices) => {
   var choices = {};

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -13,7 +13,7 @@ import CssTransitionGroup from 'react-addons-css-transition-group';
 import _ from './undash';
 import utils from './utils';
 
-module.exports = function (config) {
+export default function (config) {
 
   var delegateTo = utils.delegator(config);
 

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -13,6 +13,58 @@ import CssTransitionGroup from 'react-addons-css-transition-group';
 import _ from './undash';
 import utils from './utils';
 
+import FieldsField from './components/fields/fields';
+import GroupedFieldsField from './components/fields/grouped-fields';
+import StringField from './components/fields/string';
+import SingleLineStringField from './components/fields/single-line-string';
+import PasswordField from './components/fields/password';
+import SelectField from './components/fields/select';
+import PrettySelectField from './components/fields/pretty-select';
+import BooleanField from './components/fields/boolean';
+import PrettyBooleanField from './components/fields/pretty-boolean';
+import CheckboxBooleanField from './components/fields/checkbox-boolean';
+import CodeField from './components/fields/code';
+import PrettyTextField from './components/fields/pretty-text2';
+import PrettyTagField from './components/helpers/pretty-tag';
+import ArrayField from './components/fields/array';
+import CheckboxArrayField from './components/fields/checkbox-array';
+import ObjectField from './components/fields/object';
+import AssocListField from './components/fields/assoc-list';
+import JsonField from './components/fields/json';
+import UnknownFieldField from './components/fields/unknown';
+import CopyField from './components/fields/copy';
+
+import FieldHelper from './components/helpers/field';
+import LabelHelper from './components/helpers/label';
+import HelpHelper from './components/helpers/help';
+import ChoicesHelper from './components/helpers/choices';
+import ChoicesItemHelper from './components/helpers/choices-item';
+import ChoiceHelper from './components/helpers/choice';
+import ChoicesSearchHelper from './components/helpers/choices-search';
+import LoadingChoicesHelper from './components/helpers/loading-choices';
+import LoadingChoiceHelper from './components/helpers/loading-choice';
+import ArrayControlHelper from './components/helpers/array-control';
+import ArrayItemControlHelper from './components/helpers/array-item-control';
+import ArrayItemValueHelper from './components/helpers/array-item-value';
+import ArrayItemHelper from './components/helpers/array-item';
+import FieldTemplateChoicesHelper from './components/helpers/field-template-choices';
+import AddItemHelper from './components/helpers/add-item';
+import RemoveItemHelper from './components/helpers/remove-item';
+import MoveItemForwardHelper from './components/helpers/move-item-forward';
+import MoveItemBackHelper from './components/helpers/move-item-back';
+import AssocListControlHelper from './components/helpers/assoc-list-control';
+import AssocListItemControlHelper from './components/helpers/assoc-list-item-control';
+import AssocListItemValueHelper from './components/helpers/assoc-list-item-value';
+import AssocListItemKeyHelper from './components/helpers/assoc-list-item-key';
+import AssocListItemHelper from './components/helpers/assoc-list-item';
+import SelectValueHelper from './components/helpers/select-value';
+import PrettySelectValueHelper from './components/helpers/pretty-select-value';
+import PrettySelectInputHelper from './components/helpers/pretty-select-input';
+import SampleHelper from './components/helpers/sample';
+import InsertButtonHelper from './components/helpers/insert-button';
+import ChoiceSectionHeaderHelper from './components/helpers/choice-section-header';
+import PrettyTextInputHelper from './components/helpers/pretty-text-input';
+
 export default function (config) {
 
   var delegateTo = utils.delegator(config);
@@ -21,110 +73,108 @@ export default function (config) {
 
     // Field element factories. Create field elements.
 
-    createElement_Fields: React.createFactory(require('./components/fields/fields')),
+    createElement_Fields: React.createFactory(FieldsField),
 
-    createElement_GroupedFields: React.createFactory(require('./components/fields/grouped-fields')),
+    createElement_GroupedFields: React.createFactory(GroupedFieldsField),
 
-    createElement_String: React.createFactory(require('./components/fields/string')),
+    createElement_String: React.createFactory(StringField),
 
-    createElement_SingleLineString: React.createFactory(require('./components/fields/single-line-string')),
+    createElement_SingleLineString: React.createFactory(SingleLineStringField),
 
-    createElement_Password: React.createFactory(require('./components/fields/password')),
+    createElement_Password: React.createFactory(PasswordField),
 
-    createElement_Select: React.createFactory(require('./components/fields/select')),
+    createElement_Select: React.createFactory(SelectField),
 
-    createElement_PrettySelect: React.createFactory(require('./components/fields/pretty-select')),
+    createElement_PrettySelect: React.createFactory(PrettySelectField),
 
-    createElement_Boolean: React.createFactory(require('./components/fields/boolean')),
+    createElement_Boolean: React.createFactory(BooleanField),
 
-    createElement_PrettyBoolean: React.createFactory(require('./components/fields/pretty-boolean')),
+    createElement_PrettyBoolean: React.createFactory(PrettyBooleanField),
 
-    createElement_CheckboxBoolean: React.createFactory(require('./components/fields/checkbox-boolean')),
+    createElement_CheckboxBoolean: React.createFactory(CheckboxBooleanField),
 
-    // createElement_PrettyText: React.createFactory(require('./components/fields/pretty-text')),
+    createElement_Code: React.createFactory(CodeField),
 
-    createElement_Code: React.createFactory(require('./components/fields/code')),
+    createElement_PrettyText: React.createFactory(PrettyTextField),
 
-    createElement_PrettyText: React.createFactory(require('./components/fields/pretty-text2')),
+    createElement_PrettyTag: React.createFactory(PrettyTagField),
 
-    createElement_PrettyTag: React.createFactory(require('./components/helpers/pretty-tag')),
+    createElement_Array: React.createFactory(ArrayField),
 
-    createElement_Array: React.createFactory(require('./components/fields/array')),
+    createElement_CheckboxArray: React.createFactory(CheckboxArrayField),
 
-    createElement_CheckboxArray: React.createFactory(require('./components/fields/checkbox-array')),
+    createElement_Object: React.createFactory(ObjectField),
 
-    createElement_Object: React.createFactory(require('./components/fields/object')),
+    createElement_AssocList: React.createFactory(AssocListField),
 
-    createElement_AssocList: React.createFactory(require('./components/fields/assoc-list')),
+    createElement_Json: React.createFactory(JsonField),
 
-    createElement_Json: React.createFactory(require('./components/fields/json')),
+    createElement_UnknownField: React.createFactory(UnknownFieldField),
 
-    createElement_UnknownField: React.createFactory(require('./components/fields/unknown')),
-
-    createElement_Copy: React.createFactory(require('./components/fields/copy')),
+    createElement_Copy: React.createFactory(CopyField),
 
 
     // Other element factories. Create helper elements used by field components.
 
-    createElement_Field: React.createFactory(require('./components/helpers/field')),
+    createElement_Field: React.createFactory(FieldHelper),
 
-    createElement_Label: React.createFactory(require('./components/helpers/label')),
+    createElement_Label: React.createFactory(LabelHelper),
 
-    createElement_Help: React.createFactory(require('./components/helpers/help')),
+    createElement_Help: React.createFactory(HelpHelper),
 
-    createElement_Choices: React.createFactory(require('./components/helpers/choices')),
+    createElement_Choices: React.createFactory(ChoicesHelper),
 
-    createElement_ChoicesItem: React.createFactory(require('./components/helpers/choices-item')),
+    createElement_ChoicesItem: React.createFactory(ChoicesItemHelper),
 
-    createElement_Choice: React.createFactory(require('./components/helpers/choice')),
+    createElement_Choice: React.createFactory(ChoiceHelper),
 
-    createElement_ChoicesSearch: React.createFactory(require('./components/helpers/choices-search')),
+    createElement_ChoicesSearch: React.createFactory(ChoicesSearchHelper),
 
-    createElement_LoadingChoices: React.createFactory(require('./components/helpers/loading-choices')),
+    createElement_LoadingChoices: React.createFactory(LoadingChoicesHelper),
 
-    createElement_LoadingChoice: React.createFactory(require('./components/helpers/loading-choice')),
+    createElement_LoadingChoice: React.createFactory(LoadingChoiceHelper),
 
-    createElement_ArrayControl: React.createFactory(require('./components/helpers/array-control')),
+    createElement_ArrayControl: React.createFactory(ArrayControlHelper),
 
-    createElement_ArrayItemControl: React.createFactory(require('./components/helpers/array-item-control')),
+    createElement_ArrayItemControl: React.createFactory(ArrayItemControlHelper),
 
-    createElement_ArrayItemValue: React.createFactory(require('./components/helpers/array-item-value')),
+    createElement_ArrayItemValue: React.createFactory(ArrayItemValueHelper),
 
-    createElement_ArrayItem: React.createFactory(require('./components/helpers/array-item')),
+    createElement_ArrayItem: React.createFactory(ArrayItemHelper),
 
-    createElement_FieldTemplateChoices: React.createFactory(require('./components/helpers/field-template-choices')),
+    createElement_FieldTemplateChoices: React.createFactory(FieldTemplateChoicesHelper),
 
-    createElement_AddItem: React.createFactory(require('./components/helpers/add-item')),
+    createElement_AddItem: React.createFactory(AddItemHelper),
 
-    createElement_RemoveItem: React.createFactory(require('./components/helpers/remove-item')),
+    createElement_RemoveItem: React.createFactory(RemoveItemHelper),
 
-    createElement_MoveItemForward: React.createFactory(require('./components/helpers/move-item-forward')),
+    createElement_MoveItemForward: React.createFactory(MoveItemForwardHelper),
 
-    createElement_MoveItemBack: React.createFactory(require('./components/helpers/move-item-back')),
+    createElement_MoveItemBack: React.createFactory(MoveItemBackHelper),
 
-    createElement_AssocListControl: React.createFactory(require('./components/helpers/assoc-list-control')),
+    createElement_AssocListControl: React.createFactory(AssocListControlHelper),
 
-    createElement_AssocListItemControl: React.createFactory(require('./components/helpers/assoc-list-item-control')),
+    createElement_AssocListItemControl: React.createFactory(AssocListItemControlHelper),
 
-    createElement_AssocListItemValue: React.createFactory(require('./components/helpers/assoc-list-item-value')),
+    createElement_AssocListItemValue: React.createFactory(AssocListItemValueHelper),
 
-    createElement_AssocListItemKey: React.createFactory(require('./components/helpers/assoc-list-item-key')),
+    createElement_AssocListItemKey: React.createFactory(AssocListItemKeyHelper),
 
-    createElement_AssocListItem: React.createFactory(require('./components/helpers/assoc-list-item')),
+    createElement_AssocListItem: React.createFactory(AssocListItemHelper),
 
-    createElement_SelectValue: React.createFactory(require('./components/helpers/select-value')),
+    createElement_SelectValue: React.createFactory(SelectValueHelper),
 
-    createElement_PrettySelectValue: React.createFactory(require('./components/helpers/pretty-select-value')),
+    createElement_PrettySelectValue: React.createFactory(PrettySelectValueHelper),
 
-    createElement_PrettySelectInput: React.createFactory(require('./components/helpers/pretty-select-input')),
+    createElement_PrettySelectInput: React.createFactory(PrettySelectInputHelper),
 
-    createElement_Sample: React.createFactory(require('./components/helpers/sample')),
+    createElement_Sample: React.createFactory(SampleHelper),
 
-    createElement_InsertButton: React.createFactory(require('./components/helpers/insert-button')),
+    createElement_InsertButton: React.createFactory(InsertButtonHelper),
 
-    createElement_ChoiceSectionHeader: React.createFactory(require('./components/helpers/choice-section-header')),
+    createElement_ChoiceSectionHeader: React.createFactory(ChoiceSectionHeaderHelper),
 
-    createElement_PrettyTextInput: React.createFactory(require('./components/helpers/pretty-text-input')),
+    createElement_PrettyTextInput: React.createFactory(PrettyTextInputHelper),
 
     // Field default value factories. Give a default value for a specific type.
 
@@ -1130,4 +1180,4 @@ export default function (config) {
       return true;
     }
   };
-};
+}

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -8,11 +8,10 @@ methods you want to add or override.
 
 'use strict';
 
-var React = require('react');
-var CssTransitionGroup = require('react-addons-css-transition-group');
-var _ = require('./undash');
-
-var utils = require('./utils');
+import React from 'react';
+import CssTransitionGroup from 'react-addons-css-transition-group';
+import _ from './undash';
+import utils from './utils';
 
 module.exports = function (config) {
 

--- a/lib/formatic.js
+++ b/lib/formatic.js
@@ -17,6 +17,19 @@ import _ from './undash';
 import utils from './utils';
 import defaultConfigPlugin from './default-config';
 
+
+import ClickOutsideMixin from './mixins/click-outside.js';
+import FieldMixin from './mixins/field.js';
+import HelperMixin from './mixins/helper.js';
+import ResizeMixin from './mixins/resize.js';
+import ScrollMixin from './mixins/scroll.js';
+import UndoStackMixin from './mixins/undo-stack.js';
+
+import bootstrapPlugin from './plugins/bootstrap';
+import metaPlugin from './plugins/meta';
+import referencePlugin from './plugins/reference';
+import elementClassesPlugin from './plugins/element-classes';
+
 var createConfig = function (...args) {
   var plugins = [defaultConfigPlugin].concat(args);
 
@@ -84,18 +97,18 @@ export default React.createClass({
   statics: {
     createConfig: createConfig,
     availableMixins: {
-      clickOutside: require('./mixins/click-outside.js'),
-      field: require('./mixins/field.js'),
-      helper: require('./mixins/helper.js'),
-      resize: require('./mixins/resize.js'),
-      scroll: require('./mixins/scroll.js'),
-      undoStack: require('./mixins/undo-stack.js')
+      clickOutside: ClickOutsideMixin,
+      field: FieldMixin,
+      helper: HelperMixin,
+      resize: ResizeMixin,
+      scroll: ScrollMixin,
+      undoStack: UndoStackMixin
     },
     plugins: {
-      bootstrap: require('./plugins/bootstrap'),
-      meta: require('./plugins/meta'),
-      reference: require('./plugins/reference'),
-      elementClasses: require('./plugins/element-classes')
+      bootstrap: bootstrapPlugin,
+      meta: metaPlugin,
+      reference: referencePlugin,
+      elementClasses: elementClassesPlugin
     },
     utils: utils
   },

--- a/lib/formatic.js
+++ b/lib/formatic.js
@@ -76,7 +76,7 @@ var FormaticControlled = React.createFactory(FormaticControlledClass);
 // A wrapper component that is actually exported and can allow formatic to be
 // used in an "uncontrolled" manner. (See uncontrolled components in the React
 // documentation for an explanation of the difference.)
-module.exports = React.createClass({
+export default React.createClass({
 
   displayName: 'Formatic',
 

--- a/lib/formatic.js
+++ b/lib/formatic.js
@@ -12,12 +12,10 @@ is what is actually exported.
 
 'use strict';
 
-var React = require('react');
-var _ = require('./undash');
-
-var utils = require('./utils');
-
-var defaultConfigPlugin = require('./default-config');
+import React from 'react';
+import _ from './undash';
+import utils from './utils';
+import defaultConfigPlugin from './default-config';
 
 var createConfig = function (...args) {
   var plugins = [defaultConfigPlugin].concat(args);

--- a/lib/mixins/click-outside.js
+++ b/lib/mixins/click-outside.js
@@ -6,9 +6,11 @@ this is useful, so that's what this mixin does. To use it, mix it in and use it
 from your component like this:
 
 ```js
-module.exports = React.createClass({
+import ClickOutsideMixin from '../../mixins/click-outside';
 
-  mixins: [require('../..mixins/click-outside')],
+exports default React.createClass({
+
+  mixins: [ClickOutsideMixin],
 
   onClickOutside: function () {
     console.log('clicked outside!');

--- a/lib/mixins/click-outside.js
+++ b/lib/mixins/click-outside.js
@@ -41,7 +41,7 @@ var hasAncestor = function (child, parent) {
   return hasAncestor(child.parentNode, parent);
 };
 
-module.exports = {
+export default {
 
   isNodeOutside: function (nodeOut, nodeIn) {
     if (nodeOut === nodeIn) {

--- a/lib/mixins/click-outside.js
+++ b/lib/mixins/click-outside.js
@@ -29,7 +29,7 @@ module.exports = React.createClass({
 
 'use strict';
 
-var _ = require('../undash');
+import _ from '../undash';
 
 var hasAncestor = function (child, parent) {
   if (child.parentNode === parent) {

--- a/lib/mixins/field.js
+++ b/lib/mixins/field.js
@@ -6,7 +6,7 @@ This mixin gets mixed into all field components.
 
 'use strict';
 
-var _ = require('../undash');
+import _ from '../undash';
 
 module.exports = {
 

--- a/lib/mixins/field.js
+++ b/lib/mixins/field.js
@@ -8,7 +8,7 @@ This mixin gets mixed into all field components.
 
 import _ from '../undash';
 
-module.exports = {
+export default {
 
   // Signal a change in value.
   onChangeValue: function (value) {

--- a/lib/mixins/helper.js
+++ b/lib/mixins/helper.js
@@ -6,7 +6,7 @@ This gets mixed into all helper components.
 
 'use strict';
 
-var _ = require('../undash');
+import _ from '../undash';
 
 module.exports = {
 

--- a/lib/mixins/helper.js
+++ b/lib/mixins/helper.js
@@ -8,7 +8,7 @@ This gets mixed into all helper components.
 
 import _ from '../undash';
 
-module.exports = {
+export default {
 
   // Delegate rendering back to config so it can be wrapped.
   renderWithConfig: function () {

--- a/lib/mixins/resize.js
+++ b/lib/mixins/resize.js
@@ -87,7 +87,7 @@ var onResize = function (ref, fn) {
   fn(ref);
 };
 
-module.exports = {
+export default {
 
   componentDidMount: function () {
     if (this.onResizeWindow) {

--- a/lib/mixins/resize.js
+++ b/lib/mixins/resize.js
@@ -7,9 +7,11 @@ So, using good ol' polling here. To try to be as efficient as possible, there
 is only a single setInterval used for all elements. To use:
 
 ```js
-module.exports = React.createClass({
+import ResizeMixin from '../../mixins/resize';
 
-  mixins: [require('../../mixins/resize')],
+export default React.createClass({
+
+  mixins: [ResizeMixin],
 
   onResize: function () {
     console.log('resized!');

--- a/lib/mixins/scroll.js
+++ b/lib/mixins/scroll.js
@@ -22,4 +22,4 @@ export default function (plugin) {
       }
     }
   };
-};
+}

--- a/lib/mixins/scroll.js
+++ b/lib/mixins/scroll.js
@@ -6,7 +6,7 @@ Currently unused.
 
 'use strict';
 
-module.exports = function (plugin) {
+export default function (plugin) {
 
   plugin.exports = {
 

--- a/lib/mixins/undo-stack.js
+++ b/lib/mixins/undo-stack.js
@@ -8,7 +8,7 @@ Gives your component an undo stack.
 
 'use strict';
 
-module.exports = {
+export default {
   getInitialState: function() {
     return {undo: [], redo: []};
   },

--- a/lib/plugins/bootstrap.js
+++ b/lib/plugins/bootstrap.js
@@ -55,4 +55,4 @@ export default function (config) {
       return createElement(name, props, children);
     }
   };
-};
+}

--- a/lib/plugins/bootstrap.js
+++ b/lib/plugins/bootstrap.js
@@ -7,7 +7,7 @@ with Twitter Bootstrap.
 
 'use strict';
 
-var _ = require('../undash');
+import _ from '../undash';
 
 // Declare some classes and labels for each element.
 var modifiers = {

--- a/lib/plugins/bootstrap.js
+++ b/lib/plugins/bootstrap.js
@@ -32,7 +32,7 @@ var modifiers = {
   'SelectValue': {classes: {'form-control': true}}
 };
 
-module.exports = function (config) {
+export default function (config) {
 
   var createElement = config.createElement;
 

--- a/lib/plugins/element-classes.js
+++ b/lib/plugins/element-classes.js
@@ -7,7 +7,7 @@ class to an element.
 
 'use strict';
 
-var _ = require('../undash');
+import _ from '../undash';
 
 module.exports = function (config) {
 

--- a/lib/plugins/element-classes.js
+++ b/lib/plugins/element-classes.js
@@ -9,7 +9,7 @@ class to an element.
 
 import _ from '../undash';
 
-module.exports = function (config) {
+export default function (config) {
 
   var createElement = config.createElement;
 

--- a/lib/plugins/element-classes.js
+++ b/lib/plugins/element-classes.js
@@ -39,4 +39,4 @@ export default function (config) {
       return createElement(name, props, children);
     }
   };
-};
+}

--- a/lib/plugins/meta.js
+++ b/lib/plugins/meta.js
@@ -30,4 +30,4 @@ export default function (config) {
       initField(field);
     }
   };
-};
+}

--- a/lib/plugins/meta.js
+++ b/lib/plugins/meta.js
@@ -8,7 +8,7 @@ get your meta values.
 
 'use strict';
 
-module.exports = function (config) {
+export default function (config) {
 
   var initRootField = config.initRootField;
   var initField = config.initField;

--- a/lib/plugins/reference.js
+++ b/lib/plugins/reference.js
@@ -8,7 +8,7 @@ extends: ['foo', 'bar'] where 'foo' and 'bar' refer to other keys or ids.
 
 'use strict';
 
-var _ = require('../undash');
+import _ from '../undash';
 
 module.exports = function (config) {
 

--- a/lib/plugins/reference.js
+++ b/lib/plugins/reference.js
@@ -10,7 +10,7 @@ extends: ['foo', 'bar'] where 'foo' and 'bar' refer to other keys or ids.
 
 import _ from '../undash';
 
-module.exports = function (config) {
+export default function (config) {
 
   var initField = config.initField;
 

--- a/lib/plugins/reference.js
+++ b/lib/plugins/reference.js
@@ -120,4 +120,4 @@ export default function (config) {
     }
   };
 
-};
+}

--- a/lib/undash.js
+++ b/lib/undash.js
@@ -102,4 +102,4 @@ _.debounce = function(func, wait, immediate) {
   };
 };
 
-module.exports = _;
+export default _;

--- a/lib/undash.js
+++ b/lib/undash.js
@@ -1,7 +1,10 @@
 var _ = {};
 
-_.assign = _.extend = require('object-assign');
-_.isEqual = require('deep-equal');
+import objectAssign from 'object-assign';
+import deepEqual from 'deep-equal';
+
+_.assign = _.extend = objectAssign;
+_.isEqual = deepEqual;
 
 // These are not necessarily complete implementations. They're just enough for
 // what's used in formatic.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,8 +6,8 @@ Just some shared utility functions.
 
 'use strict';
 
-var _ = require('./undash');
-var ReactDOM = require('react-dom');
+import _ from './undash';
+import ReactDOM from 'react-dom';
 
 var utils = exports;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,7 @@ Just some shared utility functions.
 import _ from './undash';
 import ReactDOM from 'react-dom';
 
-var utils = exports;
+var utils = {};
 
 // Copy obj recursing deeply.
 utils.deepCopy = function (obj) {
@@ -162,3 +162,5 @@ utils.focusRefNode = (ref) => {
     node.focus();
   }
 };
+
+export default utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -121,7 +121,7 @@ utils.capitalize = function(s) {
   return s.charAt(0).toUpperCase() + s.substring(1).toLowerCase();
 };
 
-utils.keyCodes = {
+export const keyCodes = utils.keyCodes = {
   UP: 38,
   DOWN: 40,
   ENTER: 13,
@@ -140,7 +140,7 @@ utils.keyCodes = {
 //   }
 // };
 
-utils.scrollIntoContainerView = (node, container) => {
+export const scrollIntoContainerView = utils.scrollIntoContainerView = (node, container) => {
   if (node && container) {
     const nodeRect = node.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
@@ -156,7 +156,7 @@ utils.scrollIntoContainerView = (node, container) => {
   }
 };
 
-utils.focusRefNode = (ref) => {
+export const focusRefNode = utils.focusRefNode = (ref) => {
   if (ref) {
     const node = ReactDOM.findDOMNode(ref);
     node.focus();

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "es6-promise": "3.0.2",
     "eslint": "3.13.1",
     "eslint-loader": "1.1.1",
-    "eslint-plugin-react": "6.9.0",
+    "eslint-plugin-react": "6.10.3",
     "groc": "https://registry.npmjs.org/groc/-/groc-0.7.0.tgz",
     "gulp": "3.8.11",
     "gulp-gh-pages": "0.4.0",
@@ -57,8 +57,8 @@
     "react-hot-loader": "1.3.0",
     "react-tools": "0.12.2",
     "require-dir": "0.1.0",
-    "rollup": "^0.41.6",
-    "rollup-plugin-babel": "^2.7.1",
+    "rollup": "0.41.6",
+    "rollup-plugin-babel": "2.7.1",
     "run-sequence": "1.0.2",
     "shelljs": "0.3.0",
     "style-loader": "0.13.0",
@@ -68,8 +68,6 @@
   "dependencies": {
     "classnames": "^2.1.1",
     "deep-equal": "^1.0.0",
-    "eslint-plugin-react": "^6.10.3",
-    "node-libs-browser": "^2.0.0",
     "object-assign": "^2.0.0",
     "react-scroll-lock": "git+https://github.com/Laiff/react-scroll-lock.git#267bf5bcf84d334aecc20908657088007b698dc2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import babel from 'rollup-plugin-babel';
 
 export default {
-  entry: 'lib/formatic.js',
+  entry: './lib/formatic.js',
   format: 'cjs',
   external: [
     'react',
@@ -17,5 +17,5 @@ export default {
       plugins: ['external-helpers']
     }),
   ],
-  dest: 'build/lib/index.js'
+  dest: './build/lib/index.js'
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ export default {
   format: 'cjs',
   external: [
     'react',
+    'react-addons-css-transition-group',
     'react-dom'
   ],
   plugins: [


### PR DESCRIPTION
- Switched out all the `require` calls to use es6 imports instead.
- Switched out all `modules.exports` to use es6 exports instead.

Most of this used a [couple codemods](https://github.com/5to6/5to6-codemod), some was search/replace, and some was manual labor.

The immediate reason for this was to make it more friendly to rollup. In a previous commit, I started bundling with rollup, but since it was using CJS modules, it didn't do much. Had some trouble with CJS plugins, so just decided it was time to switch over anyway.