### PR TITLE
Add updates for reorder-items-in-zap-editor

### DIFF
--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -44,13 +44,13 @@ export default React.createClass({
       readOnly: isLastItem && !config.isRemovalOfLastArrayItemAllowed(field)
     });
 
-    const moveItemForward = field.fieldIndex !== field.parent.value.length - 1 ?
+    const moveItemForward = this.props.index < (this.props.numItems - 1) ?
       config.createElement('move-item-forward', {
         field: field, onClick: this.onMoveForward
       }) :
       null;
 
-    const moveItemBack = field.fieldIndex !== 0 ?
+    const moveItemBack = this.props.index > 0 ?
       config.createElement('move-item-back', {
         field: field, onClick: this.onMoveBack
       }) :

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -45,13 +45,11 @@ export default React.createClass({
     });
 
     const moveItemForward = this.props.index < (this.props.numItems - 1) ?
-      config.createElement('move-item-forward', { field: field, onClick: this.onMoveForward
-      }) :
+      config.createElement('move-item-forward', { field: field, onClick: this.onMoveForward }) :
       null;
 
     const moveItemBack = this.props.index > 0 ?
-      config.createElement('move-item-back', { field: field, onClick: this.onMoveBack
-      }) :
+      config.createElement('move-item-back', { field: field, onClick: this.onMoveBack }) :
       null;
 
     return (

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -39,17 +39,21 @@ export default React.createClass({
 
     const isLastItem = field.fieldIndex === 0 && field.parent.value.length === 1;
 
+    const isFirstItem = field.fieldIndex === 0;
+
+    const isLastMoveableItem = field.fieldIndex === field.parent.value.length -1;
+
     const removeItemControl = config.createElement('remove-item', {
       field: field, onClick: this.onRemove, onMaybeRemove: this.props.onMaybeRemove,
       readOnly: isLastItem && !config.isRemovalOfLastArrayItemAllowed(field)
     });
 
     const moveItemForward = this.props.index < (this.props.numItems - 1) ?
-      config.createElement('move-item-forward', { field: field, onClick: this.onMoveForward }) :
+      config.createElement('move-item-forward', { field: field, onClick: this.onMoveForward, classes: { 'is-first-item': isFirstItem } }) :
       null;
 
     const moveItemBack = this.props.index > 0 ?
-      config.createElement('move-item-back', { field: field, onClick: this.onMoveBack }) :
+      config.createElement('move-item-back', { field: field, onClick: this.onMoveBack, classes: { 'is-last-item': isLastMoveableItem } }) :
       null;
 
     return (

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -45,14 +45,12 @@ export default React.createClass({
     });
 
     const moveItemForward = this.props.index < (this.props.numItems - 1) ?
-      config.createElement('move-item-forward', {
-        field: field, onClick: this.onMoveForward
+      config.createElement('move-item-forward', { field: field, onClick: this.onMoveForward
       }) :
       null;
 
     const moveItemBack = this.props.index > 0 ?
-      config.createElement('move-item-back', {
-        field: field, onClick: this.onMoveBack
+      config.createElement('move-item-back', { field: field, onClick: this.onMoveBack
       }) :
       null;
 

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -44,13 +44,13 @@ export default React.createClass({
       readOnly: isLastItem && !config.isRemovalOfLastArrayItemAllowed(field)
     });
 
-    const moveItemForward = this.props.index < (this.props.numItems - 1) ?
-      config.createElement('move-item-forward', { field: field, onClick: this.onMoveForward }) :
-      null;
+    const moveItemForward = config.createElement('move-item-forward', {
+      field: field, onClick: this.onMoveForward
+    });
 
-    const moveItemBack = this.props.index > 0 ?
-      config.createElement('move-item-back', { field: field, onClick: this.onMoveBack }) :
-      null;
+    const moveItemBack = config.createElement('move-item-back', {
+      field: field, onClick: this.onMoveBack
+    });
 
     return (
       <div className={cx(this.props.classes)}>

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -44,13 +44,17 @@ export default React.createClass({
       readOnly: isLastItem && !config.isRemovalOfLastArrayItemAllowed(field)
     });
 
-    const moveItemForward = config.createElement('move-item-forward', {
-      field: field, onClick: this.onMoveForward
-    });
+    const moveItemForward = field.fieldIndex !== field.parent.value.length - 1 ?
+      config.createElement('move-item-forward', {
+        field: field, onClick: this.onMoveForward
+      }) :
+      null;
 
-    const moveItemBack = config.createElement('move-item-back', {
-      field: field, onClick: this.onMoveBack
-    });
+    const moveItemBack = field.fieldIndex !== 0 ?
+      config.createElement('move-item-back', {
+        field: field, onClick: this.onMoveBack
+      }) :
+      null;
 
     return (
       <div className={cx(this.props.classes)}>

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -283,7 +283,7 @@ export default React.createClass({
     return (
       <div onKeyDown={this.onKeyDown} className={cx({'pretty-text-wrapper': true, 'choices-open': this.state.isChoicesOpen})}
            onMouseEnter={this.switchToCodeMirror} onTouchStart={this.switchToCodeMirror}>
-        <div className="sub-pretty-text-wrapper" onClick={this.onFocusClick}>
+        <div className="pretty-text-click-wrapper" onClick={this.onFocusClick}>
           <div className={textBoxClasses} tabIndex={this.wrapperTabIndex()} onFocus={this.onFocusWrap} onBlur={this.onBlur}>
             <div ref="textBox" className="internal-text-wrapper" />
           </div>

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -283,7 +283,7 @@ export default React.createClass({
     return (
       <div onKeyDown={this.onKeyDown} className={cx({'pretty-text-wrapper': true, 'choices-open': this.state.isChoicesOpen})}
            onMouseEnter={this.switchToCodeMirror} onTouchStart={this.switchToCodeMirror}>
-        <div onClick={this.onFocusClick}>
+        <div className="sub-pretty-text-wrapper" onClick={this.onFocusClick}>
           <div className={textBoxClasses} tabIndex={this.wrapperTabIndex()} onFocus={this.onFocusWrap} onBlur={this.onBlur}>
             <div ref="textBox" className="internal-text-wrapper" />
           </div>


### PR DESCRIPTION
To be shipped with https://github.com/zapier/zapier/pull/12121

Just a few updates to the formatic code for reordering the items in the zap editor -- modifies the code a bit to show the `move-item-back` and `move-item-forward` arrows only when necessary, and adds a class to the first div child of `pretty-text-wrapper` as that needed a slight tweak for styling.