### PR TITLE
Recognize replaceChoices changes and allow tagLabel

### DIFF
--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -42,7 +42,14 @@ export default React.createClass({
   componentDidUpdate: function(prevProps, prevState) {
     const wasPreviewing = prevProps.field.meta.isPreviewing;
     const isPreviewing = this.props.field.meta.isPreviewing;
-    if (prevState.codeMirrorMode !== this.state.codeMirrorMode || wasPreviewing !== isPreviewing) {
+    if (wasPreviewing !== isPreviewing) {
+      this.setState({ codeMirrorMode: false}, () => {
+        this.createEditor();
+      });
+    }
+    if (
+      prevState.codeMirrorMode !== this.state.codeMirrorMode
+    ) {
       // Changed from code mirror mode to read only mode or vice versa,
       // so setup the other editor.
       this.createEditor();

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -40,15 +40,10 @@ export default React.createClass({
   },
 
   componentDidUpdate: function(prevProps, prevState) {
-    const wasPreviewing = prevProps.field.meta.isPreviewing;
-    const isPreviewing = this.props.field.meta.isPreviewing;
-    if (wasPreviewing !== isPreviewing) {
-      this.setState({ codeMirrorMode: false}, () => {
-        this.createEditor();
-      });
-    }
+    const replaceChoicesHaveChanged = prevProps.replaceChoices !== this.props.replaceChoices;
     if (
-      prevState.codeMirrorMode !== this.state.codeMirrorMode
+      prevState.codeMirrorMode !== this.state.codeMirrorMode ||
+      replaceChoicesHaveChanged
     ) {
       // Changed from code mirror mode to read only mode or vice versa,
       // so setup the other editor.

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -40,10 +40,9 @@ export default React.createClass({
   },
 
   componentDidUpdate: function(prevProps, prevState) {
-    const replaceChoicesHaveChanged = prevProps.replaceChoices !== this.props.replaceChoices;
+    const hasReplaceChoicesChanged = prevProps.replaceChoices !== this.props.replaceChoices;
     if (
-      prevState.codeMirrorMode !== this.state.codeMirrorMode ||
-      replaceChoicesHaveChanged
+      prevState.codeMirrorMode !== this.state.codeMirrorMode || hasReplaceChoicesChanged
     ) {
       // Changed from code mirror mode to read only mode or vice versa,
       // so setup the other editor.

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -41,9 +41,8 @@ export default React.createClass({
 
   componentDidUpdate: function(prevProps, prevState) {
     const hasReplaceChoicesChanged = prevProps.replaceChoices !== this.props.replaceChoices;
-    if (
-      prevState.codeMirrorMode !== this.state.codeMirrorMode || hasReplaceChoicesChanged
-    ) {
+    const hasCodeMirrorModeChanged = prevState.codeMirrorMode !== this.state.codeMirrorMode;
+    if (hasCodeMirrorModeChanged || hasReplaceChoicesChanged) {
       // Changed from code mirror mode to read only mode or vice versa,
       // so setup the other editor.
       this.createEditor();

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -40,7 +40,9 @@ export default React.createClass({
   },
 
   componentDidUpdate: function(prevProps, prevState) {
-    if (prevState.codeMirrorMode !== this.state.codeMirrorMode) {
+    const wasPreviewing = prevProps.field.meta.isPreviewing;
+    const isPreviewing = this.props.field.meta.isPreviewing;
+    if (prevState.codeMirrorMode !== this.state.codeMirrorMode || wasPreviewing !== isPreviewing) {
       // Changed from code mirror mode to read only mode or vice versa,
       // so setup the other editor.
       this.createEditor();

--- a/lib/components/helpers/tag-translator.js
+++ b/lib/components/helpers/tag-translator.js
@@ -3,9 +3,9 @@ import _ from '../../undash';
 
 const buildChoicesMap = (replaceChoices) => {
   var choices = {};
-  replaceChoices.forEach(function (choice) {
+  replaceChoices.forEach(function(choice) {
     var key = choice.value;
-    choices[key] = choice.label;
+    choices[key] = choice.tagLabel || choice.label;
   });
   return choices;
 };

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1100,21 +1100,20 @@ export default function (config) {
       // Array of choice arrays should be flattened.
       choices = _.compact(_.flatten(choices));
 
-      choices.forEach(function (choice, i) {
+      const choicesWithLabels = choices.map(function (choice) {
         // Convert any string choices to objects with `value` and `label`
         // properties.
-        if (_.isString(choice)) {
-          choices[i] = {
-            value: choice,
-            label: config.humanize(choice)
-          };
-        }
-        if (!choices[i].label) {
-          choices[i].label = config.humanize(choices[i].value);
-        }
+        const maybeStringChoice = _.isString(choice) ? {
+          value: choice,
+          label: config.humanize(choice)
+        } : choice;
+
+        return !maybeStringChoice.label
+        ? Object.assign({}, maybeStringChoice, { label: config.humanize(choice.value) })
+        : maybeStringChoice;
       });
 
-      return choices;
+      return choicesWithLabels;
     },
 
     // Normalize choices for a pretty drop down, with 'sample' values

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formatic",
-  "version": "0.3.85",
+  "version": "0.3.84",
   "description": "Automatic, pluggable form generation",
   "main": "./build/lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formatic",
-  "version": "0.3.84",
+  "version": "0.3.85",
   "description": "Automatic, pluggable form generation",
   "main": "./build/lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formatic",
-  "version": "0.3.83",
+  "version": "0.3.84",
   "description": "Automatic, pluggable form generation",
   "main": "./build/lib/index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds a check for `replaceChoices` changes to allow those to drive an update for codemirror. 

This PR also introduces support for `tagLabel`, which allows the user to determine the specific label for use in the tag without affecting dropdowns or other values.