### PR TITLE
Add node-libs-browser dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "jquery": "2.1.4",
     "lodash": "3.10.1",
     "marked": "0.3.6",
+    "node-libs-browser": "^2.0.0",
     "open": "0.0.5",
     "portscanner": "2.1.1",
     "react": "15.3.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jquery": "2.1.4",
     "lodash": "3.10.1",
     "marked": "0.3.6",
-    "node-libs-browser": "^2.0.0",
+    "node-libs-browser": "2.0.0",
     "open": "0.0.5",
     "portscanner": "2.1.1",
     "react": "15.3.0",


### PR DESCRIPTION
With a fresh install the `npm start` command throws the following error:

```
Error: Cannot find module 'node-libs-browser'
      at Function.Module._resolveFilename (module.js:470:15)
      at Function.Module._load (module.js:418:25)
      at Module.require (module.js:498:17)
      at require (internal/module.js:20:19)
 at Object.<anonymous> (/home/michael/Projects/javascript/react/formatic/node_modules/webpack/lib/node/NodeSourcePlugin.js:7:23)
```

Running `npm install --save-dev node-libs-browser` takes care of this. This PR just commits the addition of the dependency to package.json. I followed the pattern of setting hard version (no ^).