### PR TITLE
Migrate to React 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ node_modules
 \#*\#
 .\#*
 .projectile
+.vscode
 npm-debug.log

--- a/__tests__/actions.js
+++ b/__tests__/actions.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 
 import Formatic from '../lib/formatic';
 

--- a/__tests__/components/fields/assoc-list.js
+++ b/__tests__/components/fields/assoc-list.js
@@ -2,20 +2,20 @@
 'use strict';
 
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import Formatic from '../../../lib/formatic';
 
-const renderedKeys = doc => {
+const renderedKeys = (doc) => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'input');
   return inputs.map(i => i.value);
 };
 
-const renderedKeyClasses = doc => {
+const renderedKeyClasses = (doc) => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'input');
   return inputs.map(i => i.getAttribute('class'));
 };
 
-const renderedValues = doc => {
+const renderedValues =(doc) => {
   const textBoxes = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'textarea');
   return textBoxes.map(b => b.textContent);
 };

--- a/__tests__/components/fields/object.js
+++ b/__tests__/components/fields/object.js
@@ -2,24 +2,24 @@
 'use strict';
 
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
 import Formatic from '../../../lib/formatic';
 import ObjectClass from '../../../lib/components/fields/object';
 
-const renderedKeys = doc => {
+const renderedKeys = (doc) => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'input');
-  return inputs.map(i => i.value);
+  return inputs.map((i) => i.value);
 };
 
-const renderedKeyClasses = doc => {
+const renderedKeyClasses = (doc) => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'input');
-  return inputs.map(i => i.getAttribute('class'));
+  return inputs.map((i) => i.getAttribute('class'));
 };
 
-const renderedValues = doc => {
+const renderedValues = (doc) => {
   const textBoxes = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'textarea');
-  return textBoxes.map(b => b.textContent);
+  return textBoxes.map((b) => b.textContent);
 };
 
 describe('object field', () => {
@@ -39,8 +39,8 @@ describe('object field', () => {
   let newValue;
   let node;
 
-  const render = value => {
-    const onChange = val => {
+  const render = (value) => {
+    const onChange = (val) => {
       newValue = val;
       doc = render(newValue);
     };
@@ -51,7 +51,7 @@ describe('object field', () => {
     return TestUtils.renderIntoDocument(form);
   };
 
-  const renderToNode = value => {
+  const renderToNode = (value) => {
     const onChange = () => {};
 
     if (!node) {

--- a/__tests__/types.js
+++ b/__tests__/types.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import _ from 'lodash';
 import Formatic from '../lib/formatic';
 

--- a/docs/assets/vendor/JSXTransformer.js
+++ b/docs/assets/vendor/JSXTransformer.js
@@ -13440,22 +13440,22 @@ function addDisplayName(displayName, object, state) {
 /**
  * Transforms the following:
  *
- * var MyComponent = React.createClass({
+ * var MyComponent = createReactClass({
  *    render: ...
  * });
  *
  * into:
  *
- * var MyComponent = React.createClass({
+ * var MyComponent = createReactClass({
  *    displayName: 'MyComponent',
  *    render: ...
  * });
  *
  * Also catches:
  *
- * MyComponent = React.createClass(...);
- * exports.MyComponent = React.createClass(...);
- * module.exports = {MyComponent: React.createClass(...)};
+ * MyComponent = createReactClass(...);
+ * exports.MyComponent = createReactClass(...);
+ * module.exports = {MyComponent: createReactClass(...)};
  */
 function visitReactDisplayName(traverse, object, path, state) {
   var left, right;

--- a/docs/components/field-type.js
+++ b/docs/components/field-type.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
 var Snippet = require('./snippet');
 var ReactPlayground = require('./react-playground');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   render: function () {
 

--- a/docs/components/field-types-page.js
+++ b/docs/components/field-types-page.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var NavMain = require('./nav-main');
 var Header = require('./header');
 var Footer = require('./footer');
@@ -14,7 +15,7 @@ var Nav = Bootstrap.Nav;
 var NavItem = Bootstrap.NavItem;
 //var SubNav = Bootstrap.SubNav;
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   getInitialState: function () {
     return {

--- a/docs/components/footer.js
+++ b/docs/components/footer.js
@@ -1,10 +1,11 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var R = React.DOM;
 var pkg = require('../../package.json');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   render: function () {
     return (
       R.footer({className: 'bs-docs-footer', role: 'contentinfo'},

--- a/docs/components/getting-started-page.js
+++ b/docs/components/getting-started-page.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var NavMain = require('./nav-main');
 var Header = require('./header');
 var Footer = require('./footer');
@@ -9,7 +10,7 @@ var ReactPlayground = require('./react-playground');
 var fs = require('fs');
 var path = require('path');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   render: function () {
 

--- a/docs/components/header.js
+++ b/docs/components/header.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 //var R = React.DOM;
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   render: function () {
     return (
       <div className="bs-docs-header" id="content">

--- a/docs/components/home-page.js
+++ b/docs/components/home-page.js
@@ -1,12 +1,13 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var R = React.DOM;
 var E = React.createElement;
 var NavMain = require('./nav-main');
 var Footer = require('./footer');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   render: function () {
     return (

--- a/docs/components/nav-main.js
+++ b/docs/components/nav-main.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var Router = require('react-router');
 var Bootstrap = require('react-bootstrap');
 
@@ -22,10 +24,10 @@ var NAV_LINKS = {
   }
 };
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   propTypes: {
-    activePage: React.PropTypes.string
+    activePage: PropTypes.string
   },
 
   render: function () {

--- a/docs/components/not-found.js
+++ b/docs/components/not-found.js
@@ -1,12 +1,13 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
 var NavMain = require('./nav-main');
 var Header = require('./header');
 var Footer = require('./footer');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   render: function () {
     return (
         <div>

--- a/docs/components/plugins-page.js
+++ b/docs/components/plugins-page.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var NavMain = require('./nav-main');
 var Header = require('./header');
 var Footer = require('./footer');
@@ -13,7 +14,7 @@ var NavItem = Bootstrap.NavItem;
 var fs = require('fs');
 var path = require('path');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   getInitialState: function () {
     return {

--- a/docs/components/react-playground.js
+++ b/docs/components/react-playground.js
@@ -3,6 +3,8 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var classSet = require('react/lib/cx');
 var CodeMirror = global.CodeMirror;
 var JSXTransformer = global.JSXTransformer;
@@ -19,7 +21,7 @@ var IS_MOBILE = typeof navigator !== 'undefined' && (
     || navigator.userAgent.match(/Windows Phone/i)
   );
 
-var CodeMirrorEditor = React.createClass({
+var CodeMirrorEditor = createReactClass({
   componentDidMount: function() {
     if (IS_MOBILE) {
       return;
@@ -81,15 +83,15 @@ var selfCleaningTimeout = {
   }
 };
 
-var ReactPlayground = React.createClass({
+var ReactPlayground = createReactClass({
   mixins: [selfCleaningTimeout],
 
   MODES: {JSX: 'JSX', JS: 'JS', OUTPUT: 'OUTPUT', NONE: null},
 
   propTypes: {
-    code: React.PropTypes.string.isRequired,
-    transformer: React.PropTypes.func,
-    renderCode: React.PropTypes.bool
+    code: PropTypes.string.isRequired,
+    transformer: PropTypes.func,
+    renderCode: PropTypes.bool
   },
 
   getDefaultProps: function() {

--- a/docs/components/root.js
+++ b/docs/components/root.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var R = React.DOM;
 var E = React.createElement;
 var Router = require('react-router');
@@ -36,7 +37,7 @@ var pages = {
 
 var routes;
 
-var Root = module.exports = React.createClass({
+var Root = module.exports = createReactClass({
 
   statics: {
     renderToString: function (name) {

--- a/docs/components/snippet.js
+++ b/docs/components/snippet.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var R = React.DOM;
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   componentDidMount: function () {
     window.prettyPrint();

--- a/docs/examples/adding-field-type.js
+++ b/docs/examples/adding-field-type.js
@@ -1,6 +1,10 @@
+var React = require('react');
+var createReactClass = require('create-react-class');
+var Formatic = require('../../lib/formatic');
+
 // Our new field type is mostly represented by a React class. To make it play
 // well with others, there are some conventions to follow.
-var Tweet = React.createClass({
+var Tweet = createReactClass({
   displayName: 'Tweet',
 
   // This mixin provides the renderWithConfig method so that this fields render

--- a/lib/components/fields/array.js
+++ b/lib/components/fields/array.js
@@ -7,11 +7,12 @@ Render a field to edit array values.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Array',
 

--- a/lib/components/fields/assoc-list.js
+++ b/lib/components/fields/assoc-list.js
@@ -7,8 +7,9 @@ Render a field to edit a array of key / value objects, where duplicate keys are 
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
-import update from 'react-addons-update';
+import update from 'immutability-helper';
 
 import FieldMixin from '../../mixins/field';
 
@@ -23,7 +24,7 @@ const keyCountsByKey = (assocList) => {
   return counts;
 };
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'AssocList',
 

--- a/lib/components/fields/boolean.js
+++ b/lib/components/fields/boolean.js
@@ -6,7 +6,6 @@ Render a dropdown to handle yes/no boolean values.
 
 'use strict';
 
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';

--- a/lib/components/fields/boolean.js
+++ b/lib/components/fields/boolean.js
@@ -7,10 +7,11 @@ Render a dropdown to handle yes/no boolean values.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Boolean',
 

--- a/lib/components/fields/checkbox-array.js
+++ b/lib/components/fields/checkbox-array.js
@@ -13,6 +13,7 @@ import cx from 'classnames';
 
 import _ from '../../undash';
 import FieldMixin from '../../mixins/field';
+import { ref } from '../../utils';
 
 export default createReactClass({
 
@@ -34,7 +35,7 @@ export default createReactClass({
 
   onChange: function () {
     // Get all the checked checkboxes and convert to an array of values.
-    var choiceNodes = this.refs.choices.getElementsByTagName('input');
+    var choiceNodes = this.choices.getElementsByTagName('input');
     choiceNodes = Array.prototype.slice.call(choiceNodes, 0);
     var values = choiceNodes.map(function (node) {
       return node.checked ? node.value : null;
@@ -98,7 +99,7 @@ export default createReactClass({
     return config.createElement('field', {
       field: field
     },
-      <div className={cx(this.props.classes)} ref="choices">
+      <div className={cx(this.props.classes)} ref={ref(this, 'choices')}>
         {inputs}
       </div>
     );

--- a/lib/components/fields/checkbox-array.js
+++ b/lib/components/fields/checkbox-array.js
@@ -8,12 +8,13 @@ enumerated values to an array.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'CheckboxArray',
 

--- a/lib/components/fields/checkbox-boolean.js
+++ b/lib/components/fields/checkbox-boolean.js
@@ -7,11 +7,12 @@ Render a field that can edit a boolean with a checkbox.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'CheckboxBoolean',
 

--- a/lib/components/fields/code.js
+++ b/lib/components/fields/code.js
@@ -9,6 +9,7 @@ import cx from 'classnames';
 
 import _ from '../../undash';
 import FieldMixin from '../../mixins/field';
+import { ref } from '../../utils';
 
 /*
   A very trimmed down field that uses CodeMirror for syntax highlighting *only*.
@@ -58,7 +59,7 @@ export default createReactClass({
     var element = (
       <div className="pretty-text-wrapper">
         <div className={textBoxClasses} tabIndex={this.tabIndex()} onFocus={this.onFocusAction} onBlur={this.onBlurAction}>
-          <div ref="textBox" className="internal-text-wrapper" />
+          <div ref={ref(this, 'textBox')} className="internal-text-wrapper" />
         </div>
       </div>
     );
@@ -103,13 +104,13 @@ export default createReactClass({
       options = _.extend({}, options, this.props.field.codeMirrorOptions);
     }
 
-    var textBox = this.refs.textBox;
+    var textBox = this.textBoxRef;
     this.codeMirror = CodeMirror(textBox, options);
     this.codeMirror.on('change', this.onCodeMirrorChange);
   },
 
   removeCodeMirrorEditor: function () {
-    var textBoxNode = this.refs.textBox;
+    var textBoxNode = this.textBoxRef;
     var cmNode = textBoxNode.firstChild;
     textBoxNode.removeChild(cmNode);
     this.codeMirror = null;

--- a/lib/components/fields/code.js
+++ b/lib/components/fields/code.js
@@ -4,6 +4,7 @@
 /*eslint no-script-url:0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
@@ -12,7 +13,7 @@ import FieldMixin from '../../mixins/field';
 /*
   A very trimmed down field that uses CodeMirror for syntax highlighting *only*.
  */
-export default React.createClass({
+export default createReactClass({
   displayName: 'Code',
 
   mixins: [FieldMixin],

--- a/lib/components/fields/copy.js
+++ b/lib/components/fields/copy.js
@@ -7,11 +7,12 @@ Render non-editable html/text (think article copy).
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Copy',
 

--- a/lib/components/fields/fields.js
+++ b/lib/components/fields/fields.js
@@ -7,12 +7,13 @@ Render a field to edit the values of an object with static properties.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Fields',
 

--- a/lib/components/fields/grouped-fields.js
+++ b/lib/components/fields/grouped-fields.js
@@ -7,6 +7,7 @@ Render a fields in groups. Grouped by field.groupKey property.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
@@ -40,7 +41,7 @@ var groupFields = function (fields, humanize) {
   return groupedFields;
 };
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'GroupedFields',
 

--- a/lib/components/fields/json.js
+++ b/lib/components/fields/json.js
@@ -8,11 +8,12 @@ while the value is invalid, no external state changes will occur.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Json',
 

--- a/lib/components/fields/object.js
+++ b/lib/components/fields/object.js
@@ -7,7 +7,8 @@ Render a field to edit an object with dynamic child fields.
 'use strict';
 
 import React from 'react';
-import update from 'react-addons-update';
+import createReactClass from 'create-react-class';
+import update from 'immutability-helper';
 
 import FieldMixin from '../../mixins/field';
 
@@ -26,7 +27,7 @@ const hasDuplicateKeys = (assocList) => {
   return hasDups;
 };
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Object',
 

--- a/lib/components/fields/object.js
+++ b/lib/components/fields/object.js
@@ -6,7 +6,6 @@ Render a field to edit an object with dynamic child fields.
 
 'use strict';
 
-import React from 'react';
 import createReactClass from 'create-react-class';
 import update from 'immutability-helper';
 

--- a/lib/components/fields/password.js
+++ b/lib/components/fields/password.js
@@ -7,11 +7,12 @@ Render a single line text input.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Password',
 

--- a/lib/components/fields/pretty-boolean.js
+++ b/lib/components/fields/pretty-boolean.js
@@ -6,7 +6,6 @@ Render pretty boolean component with non-native drop-down
 
 'use strict';
 
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';

--- a/lib/components/fields/pretty-boolean.js
+++ b/lib/components/fields/pretty-boolean.js
@@ -7,10 +7,11 @@ Render pretty boolean component with non-native drop-down
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'PrettyBoolean',
 

--- a/lib/components/fields/pretty-select.js
+++ b/lib/components/fields/pretty-select.js
@@ -7,7 +7,6 @@ select drop down and supports fancier renderings.
 
 'use strict';
 
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';

--- a/lib/components/fields/pretty-select.js
+++ b/lib/components/fields/pretty-select.js
@@ -8,10 +8,11 @@ select drop down and supports fancier renderings.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'PrettySelect',
 

--- a/lib/components/fields/pretty-text.js
+++ b/lib/components/fields/pretty-text.js
@@ -25,6 +25,7 @@ So good luck!
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
@@ -96,7 +97,7 @@ var parseTextWithTags = function (value) {
 };
 
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'TaggedText',
 

--- a/lib/components/fields/pretty-text.js
+++ b/lib/components/fields/pretty-text.js
@@ -29,7 +29,7 @@ import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
-import utils from '../../utils';
+import utils, { ref } from '../../utils';
 import FieldMixin from '../../mixins/field';
 import UndoStackMixin from '../../mixins/undo-stack';
 import ResizeMixin from '../../mixins/resize';
@@ -200,8 +200,8 @@ export default createReactClass({
 
   // Make highlight scroll match textarea scroll
   onScroll: function () {
-    this.refs.highlight.scrollTop = this.refs.content.scrollTop;
-    this.refs.highlight.scrollLeft = this.refs.content.scrollLeft;
+    this.highlightRef.scrollTop = this.contentRef.scrollTop;
+    this.highlightRef.scrollLeft = this.contentRef.scrollLeft;
   },
 
   // Given some postion, return the token index (position could be in the middle of a token)
@@ -288,9 +288,9 @@ export default createReactClass({
     this.tracking.pos = pos;
     this.tracking.range = range;
 
-    if (document.activeElement === this.refs.content) {
+    if (document.activeElement === this.contentRef) {
       // React can lose the selection, so put it back.
-      this.refs.content.setSelectionRange(pos, pos + range);
+      this.contentRef.setSelectionRange(pos, pos + range);
     }
   },
 
@@ -341,7 +341,7 @@ export default createReactClass({
           <span
             key={i}
             className={className}
-            ref={pillRef}
+            ref={ref(this, pillRef)}
             data-pretty={true}
             data-ref={pillRef}>
             <span className="pretty-part-left">{LEFT_PAD}</span>
@@ -503,7 +503,7 @@ export default createReactClass({
   },
 
   onCopy: function () {
-    var node = this.refs.content;
+    var node = this.contentRef;
     var start = node.selectionStart;
     var end = node.selectionEnd;
     var text = node.value.substring(start, end);
@@ -521,7 +521,7 @@ export default createReactClass({
   },
 
   onCut: function () {
-    var node = this.refs.content;
+    var node = this.contentRef;
     var start = node.selectionStart;
     var end = node.selectionEnd;
     var text = node.value.substring(start, end);
@@ -584,8 +584,8 @@ export default createReactClass({
 
   // Keep the highlight styles in sync with the textarea styles.
   adjustStyles: function (isMount) {
-    var overlay = this.refs.highlight;
-    var content = this.refs.content;
+    var overlay = this.highlightRef;
+    var content = this.contentRef;
 
     var style = window.getComputedStyle(content);
 
@@ -656,7 +656,7 @@ export default createReactClass({
       var newValue = this.rawValue(tokens);
       this.tracking.pos += this.prettyLabel(tag).length;
       this.onChangeValue(newValue);
-      this.refs.content.focus();
+      this.contentRef.focus();
     }
   },
 
@@ -680,7 +680,7 @@ export default createReactClass({
     this.setState({
       isChoicesOpen: false
     });
-    this.refs.content.focus();
+    this.contentRef.focus();
   },
 
   onToggleChoices: function () {
@@ -709,12 +709,12 @@ export default createReactClass({
   },
 
   getCloseIgnoreNodes: function () {
-    return this.refs.toggle;
+    return this.toggleRef;
   },
 
   onClickOutsideChoices: function () {
     // // If we didn't click on the toggle button, close the choices.
-    // if (this.isNodeOutside(this.refs.toggle, event.target)) {
+    // if (this.isNodeOutside(this.toggleRef, event.target)) {
     //   console.log('not a toggle click')
     //   this.setState({
     //     isChoicesOpen: false
@@ -727,7 +727,7 @@ export default createReactClass({
     // sure there's another way.
 
     var position = {x: event.clientX, y: event.clientY};
-    var nodes = this.refs.highlight.childNodes;
+    var nodes = this.highlightRef.childNodes;
     var matchedNode = null;
     for (var i = 0; i < nodes.length; i++) {
       var node = nodes[i];
@@ -765,7 +765,7 @@ export default createReactClass({
     const contentProps = {
       type: 'text',
       className: cx(_.extend({}, this.props.classes, {'pretty-content': true})),
-      ref: 'content',
+      ref: ref(this, 'content'),
       rows: field.rows || this.props.rows,
       name: field.key,
       value: this.plainValue(this.props.field.value),
@@ -793,12 +793,12 @@ export default createReactClass({
       <textarea {...contentProps} />;
 
     const insertButton = config.createElement('insert-button', {
-      ref: 'toggle',
+      ref: ref(this, 'toggle'),
       onClick: this.onToggleChoices
     }, 'Insert...');
 
     const choices = config.createElement('choices', {
-      ref: 'choices',
+      ref: ref(this, 'choices'),
       choices: replaceChoices,
       open: this.state.isChoicesOpen,
       onSelect: this.onInsert,
@@ -810,7 +810,7 @@ export default createReactClass({
       field: field, plain: this.props.plain
     },
       <div style={{ position: 'relative' }}>
-        <pre className="pretty-highlight" ref="highlight">
+        <pre className="pretty-highlight" ref={ref(this, 'highlight')}>
           {this.prettyValue(this.props.field.value)}
         </pre>
         <ContentElem />

--- a/lib/components/fields/pretty-text2.js
+++ b/lib/components/fields/pretty-text2.js
@@ -3,13 +3,14 @@
 /*eslint no-script-url:0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';
 
 /*
    Wraps a PrettyTextInput to be a stand alone field.
  */
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'PrettyText',
 

--- a/lib/components/fields/pretty-text2.js
+++ b/lib/components/fields/pretty-text2.js
@@ -2,7 +2,6 @@
 
 /*eslint no-script-url:0 */
 
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';
@@ -43,7 +42,6 @@ export default createReactClass({
       isAccordion: this.props.field.isAccordion,
       selectedChoices: this.props.config.fieldSelectedReplaceChoices(this.props.field),
       replaceChoices: this.props.config.fieldReplaceChoices(this.props.field),
-      ref: 'textBox',
       readOnly: readOnly
     });
 

--- a/lib/components/fields/select.js
+++ b/lib/components/fields/select.js
@@ -9,10 +9,11 @@ boolean values, but it _should_ work for other values.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Select',
 

--- a/lib/components/fields/select.js
+++ b/lib/components/fields/select.js
@@ -8,7 +8,6 @@ boolean values, but it _should_ work for other values.
 
 'use strict';
 
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';

--- a/lib/components/fields/single-line-string.js
+++ b/lib/components/fields/single-line-string.js
@@ -7,11 +7,12 @@ Render a single line text input.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'SingleLineString',
 

--- a/lib/components/fields/string.js
+++ b/lib/components/fields/string.js
@@ -7,11 +7,12 @@ Render a field that can edit a string value.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'String',
 

--- a/lib/components/fields/unknown.js
+++ b/lib/components/fields/unknown.js
@@ -7,10 +7,11 @@ Render a field with an unknown type.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import FieldMixin from '../../mixins/field';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Unknown',
 

--- a/lib/components/helpers/add-item.js
+++ b/lib/components/helpers/add-item.js
@@ -7,11 +7,12 @@ The add button to append an item to a field.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'AddItem',
 

--- a/lib/components/helpers/array-control.js
+++ b/lib/components/helpers/array-control.js
@@ -7,11 +7,12 @@ Render the item type choices and the add button for an array.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ArrayControl',
 

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -7,11 +7,12 @@ Render the remove and move buttons for an array field.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ArrayItemControl',
 

--- a/lib/components/helpers/array-item-control.js
+++ b/lib/components/helpers/array-item-control.js
@@ -42,7 +42,7 @@ export default createReactClass({
 
     const isFirstItem = field.fieldIndex === 0;
 
-    const isLastMoveableItem = field.fieldIndex === field.parent.value.length -1;
+    const isLastMoveableItem = field.fieldIndex === field.parent.value.length - 1;
 
     const removeItemControl = config.createElement('remove-item', {
       field: field, onClick: this.onRemove, onMaybeRemove: this.props.onMaybeRemove,

--- a/lib/components/helpers/array-item-value.js
+++ b/lib/components/helpers/array-item-value.js
@@ -7,11 +7,12 @@ Render the value of an array item.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ArrayItemValue',
 

--- a/lib/components/helpers/array-item.js
+++ b/lib/components/helpers/array-item.js
@@ -7,12 +7,13 @@ Render an array item.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 import _ from '../../undash';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ArrayItem',
 

--- a/lib/components/helpers/assoc-list-control.js
+++ b/lib/components/helpers/assoc-list-control.js
@@ -7,11 +7,12 @@ Render the item type choices and the add button.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ObjectControl',
 

--- a/lib/components/helpers/assoc-list-item-control.js
+++ b/lib/components/helpers/assoc-list-item-control.js
@@ -7,11 +7,12 @@ Render the remove buttons for an object item.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'AssocListItemControl',
 

--- a/lib/components/helpers/assoc-list-item-key.js
+++ b/lib/components/helpers/assoc-list-item-key.js
@@ -7,12 +7,13 @@ Render an object item key editor.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 import _ from '../../undash';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'AssocListItemKey',
 

--- a/lib/components/helpers/assoc-list-item-value.js
+++ b/lib/components/helpers/assoc-list-item-value.js
@@ -7,11 +7,12 @@ Render the value of an object item.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'AssocListItemValue',
 

--- a/lib/components/helpers/assoc-list-item.js
+++ b/lib/components/helpers/assoc-list-item.js
@@ -7,11 +7,12 @@ Render an object item.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'AssocListItem',
 

--- a/lib/components/helpers/choice-section-header.js
+++ b/lib/components/helpers/choice-section-header.js
@@ -7,11 +7,12 @@ Render section header in choices dropdown
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ChoiceSectionHeader',
 

--- a/lib/components/helpers/choice.js
+++ b/lib/components/helpers/choice.js
@@ -7,10 +7,11 @@ A single choice in a list of choices.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Choice',
 

--- a/lib/components/helpers/choice.js
+++ b/lib/components/helpers/choice.js
@@ -10,6 +10,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
+import { ref } from '../../utils';
 
 export default createReactClass({
 
@@ -38,7 +39,7 @@ export default createReactClass({
 
     return (
       <a style={{cursor: 'pointer'}} onClick={this.onSelect}>
-        <span ref="label" className="choice-label">{choice.label}</span>
+        <span ref={ref(this, 'label')} className="choice-label">{choice.label}</span>
         <span className="choice-sample">{this.sampleString(choice.sample)}</span>
       </a>
     );

--- a/lib/components/helpers/choices-dropdown.js
+++ b/lib/components/helpers/choices-dropdown.js
@@ -1,6 +1,8 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import _ from '../../undash';
 import HelperMixin from '../../mixins/helper';
@@ -14,14 +16,14 @@ import HelperMixin from '../../mixins/helper';
    TODO: Implemented via Bootstrap dropdown for now but we
    want to remove that dependency.
  */
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ChoicesDropdown',
 
   mixins: [HelperMixin],
 
   propTypes: {
-    handleSelection: React.PropTypes.func.isRequired
+    handleSelection: PropTypes.func.isRequired
   },
 
   handleClick: function (key) {

--- a/lib/components/helpers/choices-dropdown.js
+++ b/lib/components/helpers/choices-dropdown.js
@@ -6,6 +6,7 @@ import createReactClass from 'create-react-class';
 
 import _ from '../../undash';
 import HelperMixin from '../../mixins/helper';
+import { ref } from '../../utils';
 
 /*
    Choices drop down component for picking pretty text tags.
@@ -65,7 +66,7 @@ export default createReactClass({
 
     return (
       <div className="dropdown">
-        <a ref="dropdownToggle" href="#" className="dropdown-toggle" data-toggle="dropdown">Insert...</a>
+        <a ref={ref(this, 'dropdownToggle')} href="#" className="dropdown-toggle" data-toggle="dropdown">Insert...</a>
         <ul className="dropdown-menu">
           {items}
         </ul>

--- a/lib/components/helpers/choices-item.js
+++ b/lib/components/helpers/choices-item.js
@@ -7,12 +7,13 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ChoicesItem',
 

--- a/lib/components/helpers/choices-search.js
+++ b/lib/components/helpers/choices-search.js
@@ -7,10 +7,11 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'ChoicesSearch',
 

--- a/lib/components/helpers/choices-search.js
+++ b/lib/components/helpers/choices-search.js
@@ -10,6 +10,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
+import { ref } from '../../utils';
 
 export default createReactClass({
 
@@ -18,7 +19,7 @@ export default createReactClass({
   mixins: [HelperMixin],
 
   focus() {
-    this.refs.input.focus();
+    this.inputRef.focus();
   },
 
   render: function () {
@@ -28,7 +29,7 @@ export default createReactClass({
   renderDefault: function () {
     return (
       <div className="choices-search">
-        <input ref="input" type="text" placeholder="Search..." onChange={this.props.onChange}/>
+        <input ref={ref(this, 'input')} type="text" placeholder="Search..." onChange={this.props.onChange}/>
       </div>
     );
   }

--- a/lib/components/helpers/choices.js
+++ b/lib/components/helpers/choices.js
@@ -7,6 +7,7 @@ Render customized (non-native) dropdown choices.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import ScrollLock from 'react-scroll-lock';
 
@@ -46,7 +47,7 @@ const getInitiallyOpenSections = (choices = []) => (
     .map((choice) => choice.sectionKey)
 );
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Choices',
 

--- a/lib/components/helpers/choices.js
+++ b/lib/components/helpers/choices.js
@@ -12,7 +12,7 @@ import ReactDOM from 'react-dom';
 import ScrollLock from 'react-scroll-lock';
 
 import _ from '../../undash';
-import {keyCodes, scrollIntoContainerView} from '../../utils';
+import {keyCodes, ref, scrollIntoContainerView} from '../../utils';
 import HelperMixin from '../../mixins/helper';
 import ClickOutsideMixin from '../../mixins/click-outside';
 
@@ -109,8 +109,8 @@ export default createReactClass({
       }
     }.bind(this));
 
-    if (this.refs.search) {
-      this.refs.search.focus();
+    if (this.searchRef) {
+      this.searchRef.focus();
     }
 
     this.adjustSize();
@@ -149,7 +149,7 @@ export default createReactClass({
   // Can't using scrolling events, because we might be scrolling inside a container instead of the body.
   // Shouldn't be any more costly than animations though, I think. And only one of these is open at a time.
   updateListeningToWindow: function () {
-    if (this.refs.choices) {
+    if (this.choicesRef) {
       if (!this.isListening) {
         const listenToFrame = () => {
           requestAnimationFrameThrottled(3, () => {
@@ -181,8 +181,8 @@ export default createReactClass({
 
   adjustSize: function (cb) {
     let didSetState = false;
-    if (this.refs.choices) {
-      var node = this.refs.container;
+    if (this.choicesRef) {
+      var node = this.containerRef;
       var rect = node.getBoundingClientRect();
       var top = rect.top;
       var windowHeight = window.innerHeight;
@@ -218,8 +218,8 @@ export default createReactClass({
 
     this.setState(nextState, () => {
       if (isOpening || isSearchOpening) {
-        if (this.refs.search) {
-          this.refs.search.focus();
+        if (this.searchRef) {
+          this.searchRef.focus();
         }
       }
       this.adjustSize();
@@ -389,17 +389,17 @@ export default createReactClass({
           let nextHoverIndex = hoverIndex + direction;
           if (nextHoverIndex < 0) {
             nextHoverIndex = 0;
-            if (this.refs.container) {
-              const containerNode = ReactDOM.findDOMNode(this.refs.container);
+            if (this.containerRef) {
+              const containerNode = ReactDOM.findDOMNode(this.containerRef);
               containerNode.scrollTop = 0;
             }
           } else if (nextHoverIndex + 1 > visibleChoices.length) {
             nextHoverIndex = visibleChoices.length - 1;
           }
-          const nextHoverComponent = this.refs[`choice-${nextHoverIndex}`];
-          if (nextHoverComponent && this.refs.container) {
+          const nextHoverComponent = this[`choice-${nextHoverIndex}Ref`];
+          if (nextHoverComponent && this.containerRef) {
             const node = ReactDOM.findDOMNode(nextHoverComponent);
-            const containerNode = ReactDOM.findDOMNode(this.refs.container);
+            const containerNode = ReactDOM.findDOMNode(this.containerRef);
             scrollIntoContainerView(node, containerNode);
           }
           const nextHoverValue = nextHoverIndex > -1 ? (
@@ -408,8 +408,8 @@ export default createReactClass({
             'search'
           );
           if (nextHoverValue === 'search') {
-            if (this.refs.search) {
-              this.refs.search.focus();
+            if (this.searchRef) {
+              this.searchRef.focus();
             }
           }
           this.setState({
@@ -463,7 +463,7 @@ export default createReactClass({
 
     return (
       <div
-        ref="container"
+        ref={ref(this, 'container')}
         onClick={this.onClick}
         className="choices-container"
         style={{
@@ -476,7 +476,7 @@ export default createReactClass({
           search,
           <ul
             key="choices"
-            ref="choices"
+            ref={ref(this, 'choices')}
             className="choices">
             {
               choices.map(function (choice, i) {

--- a/lib/components/helpers/field-template-choices.js
+++ b/lib/components/helpers/field-template-choices.js
@@ -7,11 +7,12 @@ Give a list of choices of item types to create as children of an field.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'FieldTemplateChoices',
 

--- a/lib/components/helpers/field.js
+++ b/lib/components/helpers/field.js
@@ -7,12 +7,13 @@ Used by any fields to put the label and help text around the field.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import _ from '../../undash';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Field',
 

--- a/lib/components/helpers/help.js
+++ b/lib/components/helpers/help.js
@@ -7,11 +7,12 @@ Just the help text block.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Help',
 

--- a/lib/components/helpers/insert-button.js
+++ b/lib/components/helpers/insert-button.js
@@ -1,22 +1,24 @@
+'use strict';
+
 // # button component
 
 /*
   Clickable 'button'
 */
 
-'use strict';
-
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'InsertButton',
 
   propTypes: {
-    onClick: React.PropTypes.func.isRequired
+    onClick: PropTypes.func.isRequired
   },
 
   mixins: [HelperMixin],

--- a/lib/components/helpers/label.js
+++ b/lib/components/helpers/label.js
@@ -7,11 +7,12 @@ Just the label for a field.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Label',
 

--- a/lib/components/helpers/loading-choice.js
+++ b/lib/components/helpers/loading-choice.js
@@ -1,10 +1,11 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'LoadingChoice',
 

--- a/lib/components/helpers/loading-choices.js
+++ b/lib/components/helpers/loading-choices.js
@@ -1,10 +1,11 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'LoadingChoices',
 

--- a/lib/components/helpers/move-item-back.js
+++ b/lib/components/helpers/move-item-back.js
@@ -7,11 +7,12 @@ Button to move an item backwards in list.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'MoveItemBack',
 

--- a/lib/components/helpers/move-item-forward.js
+++ b/lib/components/helpers/move-item-forward.js
@@ -7,11 +7,12 @@ Button to move an item forward in a list.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'MoveItemForward',
 

--- a/lib/components/helpers/pretty-select-input.js
+++ b/lib/components/helpers/pretty-select-input.js
@@ -6,7 +6,6 @@
 
 'use strict';
 
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
@@ -22,13 +21,13 @@ export default createReactClass({
   },
 
   focus: function () {
-    if (this.refs.textBox && this.refs.textBox.focus) {
-      this.refs.textBox.focus();
+    if (this.textBoxRef && this.textBoxRef.focus) {
+      this.textBoxRef.focus();
     }
   },
 
   setChoicesOpen: function (isOpenChoices) {
-    this.refs.textBox.setChoicesOpen(isOpenChoices);
+    this.textBoxRef.setChoicesOpen(isOpenChoices);
   },
 
   renderDefault: function () {

--- a/lib/components/helpers/pretty-select-input.js
+++ b/lib/components/helpers/pretty-select-input.js
@@ -7,10 +7,11 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'PrettySelectInput',
 

--- a/lib/components/helpers/pretty-select-value.js
+++ b/lib/components/helpers/pretty-select-value.js
@@ -13,7 +13,7 @@ import createReactClass from 'create-react-class';
 import _ from '../../undash';
 import cx from 'classnames';
 
-import {keyCodes, focusRefNode} from '../../utils';
+import {focusRefNode, keyCodes, ref} from '../../utils';
 import HelperMixin from '../../mixins/helper';
 
 export default createReactClass({
@@ -88,8 +88,8 @@ export default createReactClass({
           }
         }
       } else {
-        if (this.refs.choices && this.refs.choices.onKeyDown) {
-          this.refs.choices.onKeyDown(event);
+        if (this.choicesRef && this.choicesRef.onKeyDown) {
+          this.choicesRef.onKeyDown(event);
         }
       }
     }
@@ -101,7 +101,7 @@ export default createReactClass({
   },
 
   onFocus() {
-    focusRefNode(this.refs.container);
+    focusRefNode(this.containerRef);
   },
 
   render: function () {
@@ -160,9 +160,9 @@ export default createReactClass({
     }
 
     choicesOrLoading = (
-      <div ref="container" tabIndex="0" onKeyDown={this.onKeyDown} className={cx(_.extend({}, this.props.classes, {'choices-open': this.state.isChoicesOpen}))}
+      <div ref={ref(this, 'container')} tabIndex="0" onKeyDown={this.onKeyDown} className={cx(_.extend({}, this.props.classes, {'choices-open': this.state.isChoicesOpen}))}
            onChange={this.onChange}>
-        <div ref="toggle" onClick={this.isReadOnly() ? null : this.onToggleChoices}>
+        <div ref={ref(this, 'toggle')} onClick={this.isReadOnly() ? null : this.onToggleChoices}>
           {inputElem}
           {selectArrow}
         </div>
@@ -203,7 +203,7 @@ export default createReactClass({
   },
 
   getCloseIgnoreNodes: function () {
-    return this.refs.toggle;
+    return this.toggleRef;
   },
 
   onToggleChoices: function () {
@@ -290,12 +290,12 @@ export default createReactClass({
         isChoicesOpen: false
       }, function () {
         if (this.hasCustomField()) {
-          if (this.refs.customFieldInput && this.refs.customFieldInput.focus) {
-            this.refs.customFieldInput.focus();
+          if (this.customFieldInputRef && this.customFieldInputRef.focus) {
+            this.customFieldInputRef.focus();
           }
         } else {
-          if (this.refs.customInput && this.refs.customInput.focus) {
-            this.refs.customInput.focus();
+          if (this.customInputRef && this.customInputRef.focus) {
+            this.customInputRef.focus();
           }
         }
       });
@@ -303,7 +303,7 @@ export default createReactClass({
       this.setState({
         isChoicesOpen: false
       }, function () {
-        this.refs.customInput.setChoicesOpen(true);
+        this.customInputRef.setChoicesOpen(true);
       });
     } else {
       if (choice.action === 'clear-current-choice') {

--- a/lib/components/helpers/pretty-select-value.js
+++ b/lib/components/helpers/pretty-select-value.js
@@ -9,13 +9,14 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import _ from '../../undash';
 import cx from 'classnames';
 
 import {keyCodes, focusRefNode} from '../../utils';
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'SelectValue',
 

--- a/lib/components/helpers/pretty-tag.js
+++ b/lib/components/helpers/pretty-tag.js
@@ -1,24 +1,26 @@
+'use strict';
+
 // # pretty-tag component
 
 /*
    Pretty text tag
  */
 
-'use strict';
-
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'PrettyTag',
 
   propTypes: {
-    onClick: React.PropTypes.func,
-    classes: React.PropTypes.object
+    onClick: PropTypes.func,
+    classes: PropTypes.object
   },
 
   mixins: [HelperMixin],

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -4,6 +4,7 @@
 /*eslint no-script-url:0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import cx from 'classnames';
 
@@ -29,7 +30,7 @@ var toString = function (value) {
    instantiated when the user moves the mouse into the edit area.
    Initially a read-only view using a simple div is shown.
  */
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'PrettyTextInput',
 

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -10,7 +10,7 @@ import cx from 'classnames';
 
 import TagTranslator from './tag-translator';
 import _ from '../../undash';
-import {keyCodes} from '../../utils';
+import {keyCodes, ref} from '../../utils';
 import HelperMixin from '../../mixins/helper';
 
 var toString = function (value) {
@@ -262,8 +262,8 @@ export default createReactClass({
         //   }
         // }
       } else {
-        if (this.refs.choices && this.refs.choices.onKeyDown) {
-          this.refs.choices.onKeyDown(event);
+        if (this.choicesRef && this.choicesRef.onKeyDown) {
+          this.choicesRef.onKeyDown(event);
         }
       }
     }
@@ -286,7 +286,7 @@ export default createReactClass({
            onMouseEnter={this.switchToCodeMirror} onTouchStart={this.switchToCodeMirror}>
         <div className="pretty-text-click-wrapper" onClick={this.onFocusClick}>
           <div className={textBoxClasses} tabIndex={this.wrapperTabIndex()} onFocus={this.onFocusWrap} onBlur={this.onBlur}>
-            <div ref="textBox" className="internal-text-wrapper" />
+            <div ref={ref(this, 'textBox')} className="internal-text-wrapper" />
           </div>
         </div>
         {this.insertBtn()}
@@ -296,7 +296,7 @@ export default createReactClass({
   },
 
   getCloseIgnoreNodes: function () {
-    return this.refs.toggle;
+    return this.toggleRef;
   },
 
   onToggleChoices: function () {
@@ -353,7 +353,7 @@ export default createReactClass({
       }
     };
 
-    var textBox = this.refs.textBox;
+    var textBox = this.textBoxRef;
     textBox.innerHTML = ''; // release any previous read-only content so it can be GC'ed
 
     this.codeMirror = CodeMirror(textBox, options);
@@ -421,7 +421,7 @@ export default createReactClass({
   },
 
   createReadonlyEditor: function () {
-    var textBoxNode = this.refs.textBox;
+    var textBoxNode = this.textBoxRef;
 
     if (this.hasPlaceholder()) {
       return ReactDOM.render(<span>{this.props.field.placeholder}</span>, textBoxNode);
@@ -442,7 +442,7 @@ export default createReactClass({
   },
 
   removeCodeMirrorEditor: function () {
-    var textBoxNode = this.refs.textBox;
+    var textBoxNode = this.textBoxRef;
     var cmNode = textBoxNode.firstChild;
     textBoxNode.removeChild(cmNode);
     this.codeMirror = null;

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -376,7 +376,12 @@ export default createReactClass({
       });
     };
 
-    this.codeMirror.operation(tagOps);
+    // XXX: Make sure we apply those operation after React has made its rendering pass.
+    // As React 16 is asynchronous and uses rAF, it's same to assume that this will
+    // be called after React has patched the DOM.
+    requestAnimationFrame(() => {
+      this.codeMirror.operation(tagOps);
+    });
   },
 
   onChangeAndTagCodeMirror() {

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -376,8 +376,8 @@ export default createReactClass({
       });
     };
 
-    // XXX: Make sure we apply those operation after React has made its rendering pass.
-    // As React 16 is asynchronous and uses rAF, it's same to assume that this will
+    // XXX: Make sure we apply those operations after React has made its rendering pass.
+    // As React 16 is asynchronous and uses rAF, it's safe to assume that this will
     // be called after React has patched the DOM.
     requestAnimationFrame(() => {
       this.codeMirror.operation(tagOps);

--- a/lib/components/helpers/remove-item.js
+++ b/lib/components/helpers/remove-item.js
@@ -7,12 +7,13 @@ Remove an item.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'RemoveItem',
 

--- a/lib/components/helpers/sample.js
+++ b/lib/components/helpers/sample.js
@@ -7,11 +7,12 @@ Just the help text block.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Sample',
 

--- a/lib/components/helpers/select-value.js
+++ b/lib/components/helpers/select-value.js
@@ -8,12 +8,13 @@ type.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import cx from 'classnames';
 
 import _ from '../../undash';
 import HelperMixin from '../../mixins/helper';
 
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'SelectValue',
 

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -9,7 +9,7 @@ methods you want to add or override.
 'use strict';
 
 import React from 'react';
-import CssTransitionGroup from 'react-addons-css-transition-group';
+import { CSSTransitionGroup } from 'react-transition-group';
 import _ from './undash';
 import utils from './utils';
 
@@ -565,9 +565,13 @@ export default function (config) {
 
     cssTransitionWrapper: function(...children) {
       return (
-        <CssTransitionGroup transitionName="reveal" transitionEnterTimeout={100} transitionLeaveTimeout={100}>
+        <CSSTransitionGroup
+          transitionName="reveal"
+          transitionEnterTimeout={100}
+          transitionLeaveTimeout={100}
+        >
           {children}
-        </CssTransitionGroup>
+        </CSSTransitionGroup>
       );
     },
 

--- a/lib/formatic.js
+++ b/lib/formatic.js
@@ -13,6 +13,7 @@ is what is actually exported.
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import _ from './undash';
 import utils from './utils';
 import defaultConfigPlugin from './default-config';
@@ -50,7 +51,7 @@ var createConfig = function (...args) {
 var defaultConfig = createConfig();
 
 // The main formatic component that renders the form.
-var FormaticControlledClass = React.createClass({
+var FormaticControlledClass = createReactClass({
 
   displayName: 'FormaticControlled',
 
@@ -89,7 +90,7 @@ var FormaticControlled = React.createFactory(FormaticControlledClass);
 // A wrapper component that is actually exported and can allow formatic to be
 // used in an "uncontrolled" manner. (See uncontrolled components in the React
 // documentation for an explanation of the difference.)
-export default React.createClass({
+export default createReactClass({
 
   displayName: 'Formatic',
 

--- a/lib/mixins/click-outside.js
+++ b/lib/mixins/click-outside.js
@@ -63,7 +63,7 @@ export default {
 
   _onClickMousedown: function() {
     _.each(this.clickOutsideHandlers, function (funcs, ref) {
-      if (this.refs[ref]) {
+      if (this[`${ref}Ref`]) {
         this._mousedownRefs[ref] = true;
       }
     }.bind(this));
@@ -71,8 +71,8 @@ export default {
 
   _onClickMouseup: function (event) {
     _.each(this.clickOutsideHandlers, function (funcs, ref) {
-      if (this.refs[ref] && this._mousedownRefs[ref]) {
-        if (this.isNodeOutside(event.target, this.refs[ref])) {
+      if (this[`${ref}Ref`] && this._mousedownRefs[ref]) {
+        if (this.isNodeOutside(event.target, this[`${ref}Ref`])) {
           funcs.forEach(function (fn) {
             fn.call(this, event);
           }.bind(this));

--- a/lib/mixins/click-outside.js
+++ b/lib/mixins/click-outside.js
@@ -6,9 +6,11 @@ this is useful, so that's what this mixin does. To use it, mix it in and use it
 from your component like this:
 
 ```js
+import createReactClass from 'create-react-class';
+
 import ClickOutsideMixin from '../../mixins/click-outside';
 
-exports default React.createClass({
+exports default createReactClass({
 
   mixins: [ClickOutsideMixin],
 

--- a/lib/mixins/resize.js
+++ b/lib/mixins/resize.js
@@ -7,9 +7,11 @@ So, using good ol' polling here. To try to be as efficient as possible, there
 is only a single setInterval used for all elements. To use:
 
 ```js
+import createReactClass from 'create-react-class';
+
 import ResizeMixin from '../../mixins/resize';
 
-export default React.createClass({
+export default createReactClass({
 
   mixins: [ResizeMixin],
 

--- a/lib/mixins/resize.js
+++ b/lib/mixins/resize.js
@@ -105,7 +105,7 @@ export default {
       window.removeEventListener('resize', this.onResizeWindow);
     }
     Object.keys(this.resizeElementRefs).forEach(function (ref) {
-      removeResizeIntervalHandlers(this.refs[ref]);
+      removeResizeIntervalHandlers(this[`${ref}Ref`]);
     }.bind(this));
   },
 
@@ -113,6 +113,6 @@ export default {
     if (!this.resizeElementRefs[ref]) {
       this.resizeElementRefs[ref] = true;
     }
-    addResizeIntervalHandler(this.refs[ref], onResize.bind(this, ref, fn));
+    addResizeIntervalHandler(this[`${ref}Ref`], onResize.bind(this, ref, fn));
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -163,4 +163,8 @@ export const focusRefNode = utils.focusRefNode = (ref) => {
   }
 };
 
+export const ref = utils.ref = (component, key) => (node) => {
+  component[`${key}Ref`] = node;
+};
+
 export default utils;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-preset-react": "6.11.1",
     "bootstrap": "3.3.5",
     "codemirror": "5.9.0",
-    "create-react-class": "^15.6.2",
     "css-loader": "0.23.0",
     "envify": "1.2.1",
     "es6-promise": "3.0.2",
@@ -43,7 +42,6 @@
     "gulp-load-plugins": "0.5.3",
     "gulp-run": "1.6.6",
     "gulp-shell": "0.2.8",
-    "immutability-helper": "^2.4.0",
     "jest-cli": "14.0.1",
     "jquery": "2.1.4",
     "lodash": "3.10.1",
@@ -56,7 +54,6 @@
     "react-dom": "16.0.0",
     "react-hot-loader": "^3.0.0",
     "react-tools": "0.12.2",
-    "react-transition-group": "^1.2.1",
     "require-dir": "0.1.0",
     "rollup": "0.41.6",
     "rollup-plugin-babel": "2.7.1",
@@ -68,12 +65,17 @@
   },
   "dependencies": {
     "classnames": "^2.1.1",
+    "create-react-class": "^15.6.2",
     "deep-equal": "^1.0.0",
+    "immutability-helper": "^2.4.0",
     "object-assign": "^2.0.0",
-    "react-scroll-lock": "git+https://github.com/Laiff/react-scroll-lock.git#267bf5bcf84d334aecc20908657088007b698dc2"
+    "prop-types": "^15.6.0",
+    "react-scroll-lock": "git+https://github.com/Laiff/react-scroll-lock.git#267bf5bcf84d334aecc20908657088007b698dc2",
+    "react-transition-group": "^1.2.1"
   },
   "peerDependencies": {
-    "react": ">=0.14"
+    "react": ">= 0.16",
+    "react-dom": ">= 16.0.0"
   },
   "jest": {
     "preprocessorIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-react": "6.11.1",
     "bootstrap": "3.3.5",
     "codemirror": "5.9.0",
+    "create-react-class": "^15.6.2",
     "css-loader": "0.23.0",
     "envify": "1.2.1",
     "es6-promise": "3.0.2",
@@ -42,6 +43,7 @@
     "gulp-load-plugins": "0.5.3",
     "gulp-run": "1.6.6",
     "gulp-shell": "0.2.8",
+    "immutability-helper": "^2.4.0",
     "jest-cli": "14.0.1",
     "jquery": "2.1.4",
     "lodash": "3.10.1",
@@ -49,14 +51,12 @@
     "node-libs-browser": "2.0.0",
     "open": "0.0.5",
     "portscanner": "2.1.1",
-    "react": "15.3.0",
-    "react-addons-css-transition-group": "15.3.0",
-    "react-addons-test-utils": "15.3.0",
-    "react-addons-update": "15.3.0",
+    "react": "16.0.0",
     "react-bootstrap": "0.30.2",
-    "react-dom": "15.3.0",
-    "react-hot-loader": "1.3.0",
+    "react-dom": "16.0.0",
+    "react-hot-loader": "^3.0.0",
     "react-tools": "0.12.2",
+    "react-transition-group": "^1.2.1",
     "require-dir": "0.1.0",
     "rollup": "0.41.6",
     "rollup-plugin-babel": "2.7.1",
@@ -83,6 +83,6 @@
     "testPathDirs": [
       "__tests__"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/setup-jasmine-env.js"
+    "setupTestFrameworkScriptFile": "<rootDir>/setup-jest-env.js"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,12 +7,13 @@ export default {
     'classnames',
     'create-react-class',
     'deep-equal',
-    'object-assign',
-    'react',
-    'react-transition-group',
     'immutability-helper',
+    'object-assign',
+    'prop-types',
+    'react',
     'react-dom',
-    'react-scroll-lock'
+    'react-scroll-lock',
+    'react-transition-group'
   ],
   plugins: [
     babel({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,11 +5,12 @@ export default {
   format: 'cjs',
   external: [
     'classnames',
+    'create-react-class',
     'deep-equal',
     'object-assign',
     'react',
-    'react-addons-css-transition-group',
-    'react-addons-update',
+    'react-transition-group',
+    'immutability-helper',
     'react-dom',
     'react-scroll-lock'
   ],

--- a/setup-jasmine-env.js
+++ b/setup-jasmine-env.js
@@ -1,3 +1,0 @@
-/*globals jasmine*/
-
-jasmine.VERBOSE = true;

--- a/setup-jest-env.js
+++ b/setup-jest-env.js
@@ -1,0 +1,4 @@
+// React 16 needs `requestAnimationFrame` to work properly
+global.requestAnimationFrame = function(callback) {
+  setTimeout(callback, 0);
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.js$/,
-      loaders: ['react-hot-loader', 'babel-loader'],
+      loaders: ['react-hot-loader/webpack', 'babel-loader'],
       include: [path.join(__dirname, 'lib'), path.join(__dirname, 'demo')]
     }, {
       test: /\.css$/,


### PR DESCRIPTION
Hey guys,

So this migrates Formatic to React 16 :tada:

A bunch of dependencies had to be upgraded/replaced as a side-effect but hopefully, everything's working.

To sum up:

- `react-addons-test-utils` → `react-dom/test-utils`
- `React.createClass` is no more → `create-react-class`
- `React.PropTypes` is no more → `prop-types`.
- `react-addons-css-transition-group` → `react-transition-group` (1.x).
- `react-addons-update` → `immutability-helper`.
- (optional) add a `requestAnimationFrame` polyfill to supress warnings.
- (optional) `react-hot-loader` → `react-hot-loader/webpack`.

@jdeal FYI the bug was related to the fact that we have to use `react-transition-group` 1.x for a drop-in replacement (oops).

Tests are passing and the demo seems ok, but please make a quick double check as my knowledge of this project is pretty limited for now. Thanks!