### PR TITLE
Unsubscribe from CM events when removing it

### DIFF
--- a/lib/components/fields/code.js
+++ b/lib/components/fields/code.js
@@ -113,6 +113,7 @@ export default createReactClass({
     var textBoxNode = this.textBoxRef;
     var cmNode = textBoxNode.firstChild;
     textBoxNode.removeChild(cmNode);
+    this.codeMirror.off('change', this.onCodeMirrorChange);
     this.codeMirror = null;
   },
 

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -450,6 +450,8 @@ export default createReactClass({
     var textBoxNode = this.textBoxRef;
     var cmNode = textBoxNode.firstChild;
     textBoxNode.removeChild(cmNode);
+    this.codeMirror.off('change', this.onCodeMirrorChange);
+    this.codeMirror.off('focus', this.onFocusCodeMirror);
     this.codeMirror = null;
   },
 


### PR DESCRIPTION
For some reason in production, CM seems to fire `onCodeMirrorChange` after we removed it: https://sentry.io/zapier-1/zapier-frontend/issues/370070265/.
This fix makes sure we unsubscribe from those events before we flush the CM instance away.