### PR TITLE
Fix overlapping markers

### DIFF
--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -378,12 +378,20 @@ export default createReactClass({
       });
     };
 
-    // XXX: Make sure we apply those operations after React has made its rendering pass.
+    // Make sure we apply those operations after React has made its rendering pass.
     // As React 16 is asynchronous and uses rAF, it's safe to assume that this will
     // be called after React has patched the DOM.
-    requestAnimationFrame(() => {
+    //
+    // But if we are calling this function from CodeMirror itself, we want to stay
+    // in sync with it's internal state.
+    if (this.isDebouncingCodeMirrorChange) {
       this.codeMirror.operation(tagOps);
-    });
+    }
+    else {
+      requestAnimationFrame(() => {
+        this.codeMirror.operation(tagOps);
+      });
+    }
   },
 
   onChangeAndTagCodeMirror() {
@@ -413,8 +421,8 @@ export default createReactClass({
     if (!this.debounceCodeMirrorChange) {
       this.debounceCodeMirrorChange = _.debounce(() => {
         if (this.isDebouncingCodeMirrorChange) {
-          this.isDebouncingCodeMirrorChange = false;
           this.onChangeAndTagCodeMirror();
+          this.isDebouncingCodeMirrorChange = false;
         }
       }, 200);
     }


### PR DESCRIPTION
Here is a potential fix for https://sentry.io/zapier-1/zapier-frontend/issues/410728407/.

I'm not able to reproduce it locally hence "potential", but I'm quite confident that it may resolve the issue. The original fix was made for React 16 which uses `rAF` internally. So when `tagCodeMirror` was called from a React lifecycle event (`componentDid(Mount|Update) > createEditor > createCodeMirrorEditor`) we wanted to be sure that CodeMirror was inserted into the DOM before using it.

But `tagCodeMirror` can also be called from CodeMirror itself (`onChangeAndTagCodeMirror`) in 2 situations:
 - After inserting a new tag
 - After some user input

In the first case, we apparently also need to defer. I'm not 100% sure why but if I remove it it behaves very strangely. It might because we're calling it from React (select from the drop-down).

In the second case, it directly comes from CodeMirror. So in this situation, we don't need to defer anything, and even more, we do need to stay in sync with CodeMirror internals that may have changed?

So this PR just make sure we only defer when it's safe (basically not debouncing). And I assume it will resolve the bug as it seems to only happen when the user types something.

cc @efhjones 