### PR TITLE
compare values in replaceChoices rather than object

### DIFF
--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -41,7 +41,7 @@ export default createReactClass({
   },
 
   componentDidUpdate: function(prevProps, prevState) {
-    const hasReplaceChoicesChanged = prevProps.replaceChoices !== this.props.replaceChoices;
+    const hasReplaceChoicesChanged = _.isEqual(prevProps.replaceChoices, this.props.replaceChoices);
     const hasCodeMirrorModeChanged = prevState.codeMirrorMode !== this.state.codeMirrorMode;
     if (hasCodeMirrorModeChanged || hasReplaceChoicesChanged) {
       // Changed from code mirror mode to read only mode or vice versa,

--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -41,7 +41,7 @@ export default createReactClass({
   },
 
   componentDidUpdate: function(prevProps, prevState) {
-    const hasReplaceChoicesChanged = _.isEqual(prevProps.replaceChoices, this.props.replaceChoices);
+    const hasReplaceChoicesChanged = !_.isEqual(prevProps.replaceChoices, this.props.replaceChoices);
     const hasCodeMirrorModeChanged = prevState.codeMirrorMode !== this.state.codeMirrorMode;
     if (hasCodeMirrorModeChanged || hasReplaceChoicesChanged) {
       // Changed from code mirror mode to read only mode or vice versa,


### PR DESCRIPTION
Because it's possible to pass in an identical array with a different ref, we should check if the contents of `replaceChoices` is the same rather than doing a straight `!==` comparison. We want to avoid unnecessarily calling `this.createEditor` unless we have new `replaceChoices`. Without using `_.isEqual`, we'll trigger on all changes to `replaceChoices`, even if the contents of the array itself don't change. This can cause us to lose focus in a field we're typing if `replaceChoices` is rebuilt on render.