### PR TITLE
Bump dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jest-cli": "^21.2.1",
     "jquery": "^3.2.1",
     "lodash": "^4.17.4",
-    "marked": "^0.3.6",
+    "marked": "^0.3.9",
     "node-libs-browser": "^2.1.0",
     "open": "^0.0.5",
     "portscanner": "^2.1.1",


### PR DESCRIPTION
We should bump the 'marked' dependency for security reasons.