### PR TITLE
Bump package-lock to match marked version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formatic",
-  "version": "1.1.3",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8717,9 +8717,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "math-expression-evaluator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formatic",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Automatic, pluggable form generation",
   "main": "./build/lib/index.js",
   "scripts": {
@@ -45,7 +45,7 @@
     "jest-cli": "^21.2.1",
     "jquery": "^3.2.1",
     "lodash": "^4.17.4",
-    "marked": "^0.3.6",
+    "marked": "^0.3.9",
     "node-libs-browser": "^2.1.0",
     "open": "^0.0.5",
     "portscanner": "^2.1.1",


### PR DESCRIPTION
I forgot to commit the package-lock.json in the [PR to bump a dependency](https://github.com/zapier/formatic/pull/94) a moment ago. So let's bump it 🙄  