### PR TITLE
Make array safe for non-array values.

### DIFF
--- a/lib/components/fields/array.js
+++ b/lib/components/fields/array.js
@@ -28,7 +28,11 @@ export default createReactClass({
 
     var items = this.props.field.value;
     if (!Array.isArray(items)) {
-      items = [items];
+      if (items !== null && items !== undefined) {
+        items = [items];
+      } else {
+        items = [];
+      }
     }
 
     items.forEach(function (item, i) {

--- a/lib/components/fields/array.js
+++ b/lib/components/fields/array.js
@@ -27,6 +27,9 @@ export default createReactClass({
     var lookups = [];
 
     var items = this.props.field.value;
+    if (!Array.isArray(items)) {
+      items = [items];
+    }
 
     items.forEach(function (item, i) {
       lookups[i] = '_' + this.nextLookupId;


### PR DESCRIPTION
Shouldn't happen, but if the Array component is passed a non-array
value, turn it into an array of one element, so that the `forEach` in
getInitialState doesn't blow up.