### PR TITLE
Include requiredText as a child

### DIFF
--- a/lib/components/helpers/label.js
+++ b/lib/components/helpers/label.js
@@ -26,6 +26,12 @@ export default createReactClass({
     var config = this.props.config;
     var field = this.props.field;
     var fieldLabel = config.fieldLabel(field);
+    var fieldIsRequired = config.fieldIsRequired(field);
+    var requiredTextClassName = cx({
+      'required-text': fieldIsRequired,
+      'not-required-text': !fieldIsRequired,
+      'has-required-text': !!field.required_text,
+    });
     var label = null;
 
     if (typeof this.props.index === 'number') {
@@ -56,7 +62,7 @@ export default createReactClass({
       <div className={cx(this.props.classes)}>
         {label}
         {' '}
-        <span className={config.fieldIsRequired(field) ? 'required-text' : 'not-required-text'} />
+        <span className={requiredTextClassName}>{field.required_text}</span>
       </div>
     );
   }

--- a/lib/components/helpers/label.js
+++ b/lib/components/helpers/label.js
@@ -27,10 +27,11 @@ export default createReactClass({
     var field = this.props.field;
     var fieldLabel = config.fieldLabel(field);
     var fieldIsRequired = config.fieldIsRequired(field);
+    var requiredText = config.fieldRequiredText(field);
     var requiredTextClassName = cx({
       'required-text': fieldIsRequired,
       'not-required-text': !fieldIsRequired,
-      'has-required-text': !!field.required_text,
+      'has-required-text': !!requiredText,
     });
     var label = null;
 
@@ -62,7 +63,7 @@ export default createReactClass({
       <div className={cx(this.props.classes)}>
         {label}
         {' '}
-        <span className={requiredTextClassName}>{field.required_text}</span>
+        <span className={requiredTextClassName}>{requiredText}</span>
       </div>
     );
   }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -929,6 +929,11 @@ export default function (config) {
       return field.required ? true : false;
     },
 
+    // Get the required text for field.
+    fieldRequiredText: function (field) {
+      return field.requiredText || '';
+    },
+
     fieldHasSearch: function (field) {
       return _.isUndefined(field.hasSearch) ? true : field.hasSearch;
     },


### PR DESCRIPTION
Allows for a new, optional config key on field that will render the actual `required-text` inside the required label `<span />`. Doing this allows for custom required text to be rendered and a new className is added for additional css targeting in such cases.