### PR TITLE
Add and use RequiredLabel factory in Label

### DIFF
--- a/lib/components/helpers/label.js
+++ b/lib/components/helpers/label.js
@@ -26,7 +26,12 @@ export default createReactClass({
     var config = this.props.config;
     var field = this.props.field;
     var fieldLabel = config.fieldLabel(field);
+    var requiredLabel = config.createElement('required-label', {
+      config: config,
+      field: field,
+    });
     var label = null;
+
 
     if (typeof this.props.index === 'number') {
       label = '' + (this.props.index + 1) + '.';
@@ -56,7 +61,7 @@ export default createReactClass({
       <div className={cx(this.props.classes)}>
         {label}
         {' '}
-        <span className={config.fieldIsRequired(field) ? 'required-text' : 'not-required-text'} />
+        {requiredLabel}
       </div>
     );
   }

--- a/lib/components/helpers/required-label.js
+++ b/lib/components/helpers/required-label.js
@@ -1,0 +1,38 @@
+// # required label component
+
+/*
+  Required Label for a field
+*/
+
+'use strict';
+
+import React from 'react';
+import createReactClass from 'create-react-class';
+import cx from 'classnames';
+
+import HelperMixin from '../../mixins/helper';
+
+export default createReactClass({
+
+  displayName: 'RequiredLabel',
+
+  mixins: [HelperMixin],
+
+  render: function () {
+    return this.renderWithConfig();
+  },
+
+  renderDefault: function () {
+    var config = this.props.config;
+    var field = this.props.field;
+    var fieldIsRequired = config.fieldIsRequired(field);
+    var className = cx('required-label', {
+      'required-text': fieldIsRequired,
+      'not-required-text': !fieldIsRequired,
+    });
+
+    return (
+      <span className={className} />
+    );
+  }
+});

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -36,6 +36,7 @@ import CopyField from './components/fields/copy';
 
 import FieldHelper from './components/helpers/field';
 import LabelHelper from './components/helpers/label';
+import RequiredLabelHelper from './components/helpers/required-label';
 import HelpHelper from './components/helpers/help';
 import ChoicesHelper from './components/helpers/choices';
 import ChoicesItemHelper from './components/helpers/choices-item';
@@ -119,6 +120,8 @@ export default function (config) {
     createElement_Field: React.createFactory(FieldHelper),
 
     createElement_Label: React.createFactory(LabelHelper),
+
+    createElement_RequiredLabel: React.createFactory(RequiredLabelHelper),
 
     createElement_Help: React.createFactory(HelpHelper),
 


### PR DESCRIPTION
Replace the hardcoded `<span />` for displaying required text in a field with it's own factory element so it can be overridden/extended in a plugin.