### PR TITLE
Add CustomChoice Display Value config option

### DIFF
--- a/lib/components/helpers/pretty-select-value.js
+++ b/lib/components/helpers/pretty-select-value.js
@@ -258,11 +258,9 @@ export default createReactClass({
 
     if (this.state.isEnteringCustomValue || (!isDefaultValue && !currentChoice && currentValue)) {
       if (this.hasCustomField()) {
-        const {choices} = this.props;
+        const {choices, config} = this.props;
         const customChoice = _.find(choices, (choice) => choice.action === 'enter-custom-value');
-        if (customChoice && customChoice.label) {
-          return customChoice.label;
-        }
+        return config.customChoiceDisplayValue(customChoice, currentValue) || currentValue;
       }
       return currentValue;
     }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1170,6 +1170,10 @@ export default function (config) {
       return utils.capitalize(action).replace(/[-]/g, ' ');
     },
 
+    customChoiceDisplayValue: function (customChoice) {
+      return customChoice && customChoice.label;
+    },
+
     sortChoices: function(choices) {
       return choices;
     },


### PR DESCRIPTION
Adds a config option to override the Display Value of a field when Custom Choice is selected. Before the field would just displaying the choice's label but this option defaults to the label, allowing plugins to override this behavior and customize the displayed value.

