### PR TITLE
Add support for field messages. This will enable us to show inline er…

### DIFF
--- a/lib/components/helpers/field.js
+++ b/lib/components/helpers/field.js
@@ -96,6 +96,7 @@ export default createReactClass({
       >
         {label}
         {help}
+        {config.renderFieldMessage(this.props)}
       </div>
     );
   },

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -405,6 +405,11 @@ export default function(config) {
       return config.renderComponent(component);
     },
 
+    // Render a message below the field.
+    renderFieldMessage: function() {
+      return null;
+    },
+
     // Normalize an element name.
     elementName: function(name) {
       return utils.dashToPascal(name);


### PR DESCRIPTION
…ror messaging via plugins

This adds a hook to fields to inject a message below fields' children (which would be the input field). Using this new plugin hook and overriding individual createElement hooks for error classes, we can get colorized inline messaging.