### PR TITLE
Prevent codeMirror.operation throwing

### DIFF
--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -389,6 +389,12 @@ export default createReactClass({
     }
   },
 
+  maybeCodeMirrorOperation(ops) {
+    if (this.codeMirror) {
+      this.codeMirror.operation(ops);
+    }
+  },
+
   createCodeMirrorEditor: function() {
     const options = {
       tabindex: this.props.tabIndex || 0,
@@ -439,11 +445,11 @@ export default createReactClass({
     // But if we are calling this function from CodeMirror itself, we want to stay
     // in sync with it's internal state.
     if (this.isDebouncingCodeMirrorChange) {
-      this.codeMirror.operation(tagOps);
+      this.maybeCodeMirrorOperation(tagOps);
       this.maybeSetCursorPosition(cursorPosition);
     } else {
       requestAnimationFrame(() => {
-        this.codeMirror.operation(tagOps);
+        this.maybeCodeMirrorOperation(tagOps);
         this.maybeSetCursorPosition(cursorPosition);
       });
     }


### PR DESCRIPTION
This fixes an issue where an error is thrown because we try to access `operation` of off `this.codeMirror` when `this.codeMirror === null`.

It's set to `null` in `removeCodeMirrorEditor`, which is called when the component unmounts or `updateEditor` is called (when a particular condition is met), and presumably that happens synchronously, and then the `operation` method attempts to be called in the next frame, due to `requestAnimationFrame`.