### PR TITLE
Remove alreadySwitchedCallback from switchToCodeMirror

### DIFF
--- a/lib/components/helpers/pretty-text-input.js
+++ b/lib/components/helpers/pretty-text-input.js
@@ -149,28 +149,11 @@ export default createReactClass({
     }
   },
 
-  onFocusClick: function() {
-    this.onFocusWrapper(true);
-  },
-
-  onFocusWrapper: function(isFromClick) {
-    this.switchToCodeMirror(
-      () => {
-        this.codeMirror.focus();
-        this.codeMirror.setCursor(this.codeMirror.lineCount(), 0);
-      },
-      () => {
-        // If this is from a click, we lose focus, so force it focused!
-        if (isFromClick) {
-          setTimeout(() => {
-            if (this.codeMirror && !this.codeMirror.state.focused) {
-              this.codeMirror.focus();
-              this.codeMirror.setCursor(this.codeMirror.lineCount(), 0);
-            }
-          }, 0);
-        }
-      }
-    );
+  onFocusWrapper: function() {
+    this.switchToCodeMirror(() => {
+      this.codeMirror.focus();
+      this.codeMirror.setCursor(this.codeMirror.lineCount(), 0);
+    });
   },
 
   focus() {
@@ -321,7 +304,7 @@ export default createReactClass({
           // we need to handle onFocus events for this div for accessibility
           // when the screen reader enters the field it should be the equivalent
           // of a focus click event
-          onFocus={this.onFocusClick}
+          onFocus={this.onFocusWrapper}
           role="textbox"
         >
           <div
@@ -534,7 +517,7 @@ export default createReactClass({
     this.codeMirror = null;
   },
 
-  switchToCodeMirror: function(cb, alreadySwitchedCb) {
+  switchToCodeMirror: function(cb) {
     if (this.isReadOnly()) {
       return; // never render in code mirror if read-only
     }
@@ -545,10 +528,6 @@ export default createReactClass({
             cb();
           }
         });
-      } else {
-        if (_.isFunction(alreadySwitchedCb)) {
-          alreadySwitchedCb();
-        }
       }
     }
   },


### PR DESCRIPTION
This is a really strange bug for Windows 10. These are the reproduction steps:

1. Open up a page which has two pretty insert fields.
2. Open up another app or browser window side-by-side so that you can click directly between them without switching the tab, keeping them both in view.
3. Click on one of the pretty insert fields.
4. Click on the other app.
5. Click on a different pretty insert field
6. The cursor will jump back and forth between the two fields endlessly.

It's odd that this bug only exists on Windows 10. Testing this against a mac one thing stood out to me:

When you click the other app and then click directly back into the field, the focus event isn't called. Maybe on a mac you can't immediately focus when the current pane you're on is not the active one. It seems that on a mac, when we enter the timeout function, `codeMirror.state.focused` is true, so we don't execute `codeMirror.focus`. However on a windows machine, it's false, so we do execute `codeMirror.focus` sending us into the loop. Maybe `setTimeout` is the tiniest bit slower on windows machines, so `codeMirror.state.focused` doesn't have time to switch to true? So far I've failed to find a good explanation. But the fact that Windows keeps calling the `onFocusClick` function when the user isn't clicking is extremely strange.

Here's what happens on a windows machine:

1. A user hovers over the field before clicking. `switchToCodeMirror` is called
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L537
2. The form is not ‘read only’, so we continue into the if block
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L541-L543
3. `codeMirrorMode` is true here, so we skip the first if block
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L542-L549
4. We continue into the else block
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L542-L549
5. In the else block, the alreadySwitchedCb is a function, so we execute it
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L550
6. `isFromClick` is true. Right here, `this.codeMirror.state.focused` is `false`
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L164-L166
7. The timeout of 0ms ends and we check for code mirror and that it’s still not focused. Here, code mirror is focused, so we don’t call `codeMirror.focus()` nor do we set the cursor. Seems like all is well so far.
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L166-L168
8. The user clicks the other field
9. `switchToCodeMirror` is called, and `isReadOnly` is false, `codeMirrorMode` is true, so we continue to the else block
10. In the else block, we call the ‘alreadySwichedCb`
11. The user clicked, so we enter the if block
12. Outside the timeout, `codeMirror.state.focused` is false
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L166-L168
13. Inside the timeout, CodeMirror is still unfocused, so we call the focus function and set the cursor
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L166-L168 
14. The `focusClick` function fires again, which is a mystery to me. Maybe windows dispatches the click event again because the element didn’t immediately gain focus? Super strange.
https://github.com/zapier/formatic/blob/6fff0b82905aeeaf090383e4974634e232d2f146/lib/components/helpers/pretty-text-input.js#L152-L154

So this PR fixes the above bug by removing the second callback function, which sets the timeout for 0 ms and waits for it to execute before calling `codemirror.focus`. We call `codeMirror.focus` immediately. To be perfectly honest I'm still not 100% sure why this fixes the bug 😬 😅 only that if we don't check whether or not we _should_ focus before focusing, we can avoid it. My best theory is that windows doesn't like the minuscule wait between trying to focus the element and the element gaining focus, so it repeatedly dispatches the focus event waiting for immediate feedback.
