### PR TITLE
Send isHovering through renderTag

### DIFF
--- a/src/components/helpers/choices-item.js
+++ b/src/components/helpers/choices-item.js
@@ -33,7 +33,12 @@ export default createReactClass({
     }
 
     return (
-      <li renderWith={this.renderWith('ChoicesItem')} className={cx(classes)}>
+      <li
+        renderWith={this.renderWith('ChoicesItem', {
+          isHovering: this.props.isHovering,
+        })}
+        className={cx(classes)}
+      >
         {this.props.children}
       </li>
     );

--- a/src/plugins/css-plugin.js
+++ b/src/plugins/css-plugin.js
@@ -3,6 +3,9 @@ import cx from 'classnames';
 const plugin = config => {
   const { renderTag } = config;
   const classes = {
+    ChoicesItem: ({ isHovering }) => ({
+      'Formatic_ChoicesItem-isHovering': isHovering,
+    }),
     Field: ({ field }) => ({
       'Formatic_Field-IsReadOnly': config.fieldIsReadOnly(field),
     }),

--- a/static/css/formatic.css
+++ b/static/css/formatic.css
@@ -167,7 +167,8 @@
 
 .Formatic_PrettySelect_Choice:hover,
 .Formatic_PrettyBoolean_Choice:hover,
-.Formatic_PrettyText_Choice:hover {
+.Formatic_PrettyText_Choice:hover,
+.Formatic_ChoicesItem-isHovering {
   background-color: #eef0f2;
 }
 


### PR DESCRIPTION
This keyboard hovering is kind of janky, but while it's in place, we need to send the isHovering prop through to renderTag so we can highlight for keyboard "hovering."