### PR TITLE
Make sure we cancel the trailing debounced invocation of CM changes

### DIFF
--- a/__tests__/undash.js
+++ b/__tests__/undash.js
@@ -1,4 +1,4 @@
-/*global describe, it, expect*/
+/*global jest, describe, it, expect*/
 'use strict';
 
 import _ from '@/src/undash';
@@ -60,5 +60,44 @@ describe('utils', () => {
   it('should test for objects', () => {
     expect(_.isObject({})).toBe(true);
     expect(_.isObject(null)).toBeFalsy();
+  });
+
+  describe('debounce', () => {
+    it('should debounce invocations', done => {
+      const fn = jest.fn();
+      const debounced = _.debounce(fn, 0);
+
+      debounced();
+      debounced();
+      expect(fn.mock.calls.length).toBe(0);
+
+      setTimeout(() => {
+        expect(fn.mock.calls.length).toBe(1);
+        done();
+      }, 0);
+    });
+
+    it('should invoke a function immediatly if specified', () => {
+      const fn = jest.fn();
+      const debounced = _.debounce(fn, 0, true);
+
+      debounced();
+      expect(fn.mock.calls.length).toBe(1);
+    });
+
+    it('should be able to cancel any trailing debounced invocation', done => {
+      const fn = jest.fn();
+      const debounced = _.debounce(fn, 0);
+
+      expect(debounced).toHaveProperty('cancel');
+
+      debounced();
+      debounced.cancel();
+
+      setTimeout(() => {
+        expect(fn.mock.calls.length).toBe(0);
+        done();
+      }, 0);
+    });
   });
 });

--- a/src/components/helpers/pretty-text-input.js
+++ b/src/components/helpers/pretty-text-input.js
@@ -83,7 +83,7 @@ export default createReactClass({
   componentWillReceiveProps: function(nextProps) {
     // If we're debouncing a change, then we should just ignore this props change,
     // because there will be another when we hit the trailing edge of the debounce.
-    if (this.isDebouncingCodeMirrorChange) {
+    if (this.debouncedOnChangeAndTagCodeMirror) {
       return;
     }
 
@@ -438,7 +438,7 @@ export default createReactClass({
     //
     // But if we are calling this function from CodeMirror itself, we want to stay
     // in sync with it's internal state.
-    if (this.isDebouncingCodeMirrorChange) {
+    if (this.debouncedOnChangeAndTagCodeMirror) {
       this.maybeCodeMirrorOperation(tagOps);
       this.maybeSetCursorPosition(cursorPosition);
     } else {

--- a/src/components/helpers/pretty-text-input.js
+++ b/src/components/helpers/pretty-text-input.js
@@ -520,8 +520,12 @@ export default createReactClass({
     this.codeMirror.off('focus', this.onFocusCodeMirror);
 
     if (this.debouncedOnChangeAndTagCodeMirror) {
+      // Cancel any trailing invocation
       this.debouncedOnChangeAndTagCodeMirror.cancel();
       this.debouncedOnChangeAndTagCodeMirror = null;
+
+      // Flush changes
+      this.onChange(this.codeMirror.getValue());
     }
 
     this.codeMirror = null;

--- a/src/undash.js
+++ b/src/undash.js
@@ -90,7 +90,7 @@ _.debounce = function(func, wait, immediate) {
     }
   };
 
-  return function() {
+  const debounced = function() {
     context = this;
     args = arguments;
     timestamp = _.now();
@@ -105,6 +105,12 @@ _.debounce = function(func, wait, immediate) {
 
     return result;
   };
+
+  debounced.cancel = function() {
+    clearTimeout(timeout);
+  };
+
+  return debounced;
 };
 
 export default _;


### PR DESCRIPTION
Codemirror is regularly crashing on production: https://sentry.io/organizations/zapier-1/issues/370070265/events/4de4e354523046cdbe8a295e7aefcfdc/.

Given the `Cannot read property 'getValue' of null` error, it's very likely due to the fact that we debounce an event handler that is invoked after we got rid of the CM instance.

This PR leverage `Function#cancel` provided by `_.debounce` in order to cancel any trailing debounced invocation. This allow us to safely assume that every event handler will have a valid CM instance and help to simplify things a little bit.

I took the liberty to simplify a couple of location (cf. inline comments), but I would definitely love some experienced 👀 on this to make sure I'm not doing anything stupid.