### PR TITLE
Fix debounce problem

### DIFF
--- a/demo/examples/pretty-text.js
+++ b/demo/examples/pretty-text.js
@@ -4,18 +4,6 @@ const fields = [
     key: 'prettyText',
     type: 'pretty-text',
     default: 'Hi there {{firstName}} {{lastName}} {{middleName}}.',
-    choices: [
-      {
-        value: 'lastName',
-        label: 'Last Name',
-        sample: 'Smith',
-      },
-      {
-        value: 'middleName',
-        label:
-          'A really long label that should break somewhere in the middle and then definitely fill up all the space.',
-      },
-    ],
     replaceChoices: [
       {
         value: 'firstName',
@@ -112,6 +100,22 @@ const fields = [
         value: 'extraName',
         label: 'Extra Name',
         sample: 'Extra',
+      },
+    ],
+  },
+  {
+    label: 'Pretty Text with Dynamic Fields',
+    key: 'prettyTextDynamic',
+    type: 'pretty-text',
+    // Not a built-in, just for testing dynamic things.
+    dynamicReplaceChoices: [
+      {
+        value: 'something',
+        label: 'Something',
+      },
+      {
+        value: 'something-else',
+        label: 'Something Else',
       },
     ],
   },

--- a/src/components/helpers/pretty-text-input.js
+++ b/src/components/helpers/pretty-text-input.js
@@ -83,7 +83,7 @@ export default createReactClass({
   componentWillReceiveProps: function(nextProps) {
     // If we're debouncing a change, then we should just ignore this props change,
     // because there will be another when we hit the trailing edge of the debounce.
-    if (this.debouncedOnChangeAndTagCodeMirror) {
+    if (this.isDebouncingCodeMirrorChange) {
       return;
     }
 
@@ -408,6 +408,7 @@ export default createReactClass({
     this.codeMirror.on('focus', this.onFocusCodeMirror);
 
     this.debouncedOnChangeAndTagCodeMirror = _.debounce(() => {
+      this.isDebouncingCodeMirrorChange = false;
       this.onChangeAndTagCodeMirror();
     }, 200);
 
@@ -438,7 +439,7 @@ export default createReactClass({
     //
     // But if we are calling this function from CodeMirror itself, we want to stay
     // in sync with it's internal state.
-    if (this.debouncedOnChangeAndTagCodeMirror) {
+    if (this.isDebouncingCodeMirrorChange) {
       this.maybeCodeMirrorOperation(tagOps);
       this.maybeSetCursorPosition(cursorPosition);
     } else {
@@ -464,6 +465,7 @@ export default createReactClass({
     }
     // Otherwise, debounce so CodeMirror doesn't die.
     else {
+      this.isDebouncingCodeMirrorChange = true;
       this.debouncedOnChangeAndTagCodeMirror();
     }
   },


### PR DESCRIPTION
We made some improvements to debouncing in 2.0.4, but unfortunately, we caused a problem when we took out the flag that determined if we were in debouncing mode. That flag was used to determine when it was appropriate to update the state, so without it, we would make it impossible to load in dynamic replace choices. Now putting back the flag to fix that.

I also added in an example of dynamic replace choices in the demo to test this.

cc @ngryman 