### PR TITLE
Notify meta on value

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,1 +1,18 @@
-module.exports = require('zapier-scripts/src/config/eslint');
+module.exports = {
+  extends: './node_modules/zapier-scripts/src/config/eslint.js',
+  overrides: [
+    {
+      files: [
+        'src/components/**/*.js',
+        '**/components/mixins/**/*.js',
+        'src/formatic.js',
+      ],
+      rules: {
+        'no-restricted-syntax': [
+          0,
+          "ImportDeclaration[source.value='create-react-class']",
+        ],
+      },
+    },
+  ],
+};

--- a/__tests__/future/AutoFields.js
+++ b/__tests__/future/AutoFields.js
@@ -7,6 +7,25 @@ import { ExampleForm, defaultValue } from '@/demo/future/AutoFields';
 afterEach(cleanup);
 
 describe('AutoFields', () => {
+  function UniqueField({ fieldKey, label }) {
+    const { value, onChangeTargetValue } = useField(fieldKey);
+    return (
+      <div>
+        <div>
+          <label htmlFor={fieldKey}>Custom {label}</label>
+        </div>
+        <div>
+          <input
+            id={fieldKey}
+            onChange={onChangeTargetValue}
+            type="text"
+            value={value}
+          />
+        </div>
+      </div>
+    );
+  }
+
   test('renders fields from defaultValues', () => {
     const onChangeSpy = jest.fn();
     const { getByLabelText } = render(
@@ -72,27 +91,8 @@ describe('AutoFields', () => {
   });
 
   test('component prop overrides default field components', () => {
-    function CustomTextField({ fieldKey, label }) {
-      const { value, onChangeTargetValue } = useField(fieldKey);
-      return (
-        <div>
-          <div>
-            <label htmlFor={fieldKey}>Custom {label}</label>
-          </div>
-          <div>
-            <input
-              id={fieldKey}
-              onChange={onChangeTargetValue}
-              type="text"
-              value={value}
-            />
-          </div>
-        </div>
-      );
-    }
-
     const onChangeSpy = jest.fn();
-    const components = { string: CustomTextField };
+    const components = { string: UniqueField };
     const { getByLabelText } = render(
       <ExampleForm
         components={components}
@@ -127,5 +127,34 @@ describe('AutoFields', () => {
       lastName: 'Foo',
       age: 32,
     });
+  });
+
+  test('AutoFields update children based on value', () => {
+    const components = { string: UniqueField };
+    const { queryByLabelText, rerender } = render(
+      <ExampleForm
+        components={components}
+        onChange={() => {}}
+        value={{ firstName: 'Joe' }}
+      />
+    );
+
+    expect(queryByLabelText('Custom First Name')).toBeTruthy();
+    expect(queryByLabelText('Custom Last Name')).toBeNull();
+
+    fireEvent.change(queryByLabelText('Custom First Name'), {
+      target: { value: 'Joey' },
+    });
+
+    rerender(
+      <ExampleForm
+        components={components}
+        onChange={() => {}}
+        value={{ firstName: 'Ron', lastName: 'Burgundy' }}
+      />
+    );
+
+    expect(queryByLabelText('Custom First Name')).toBeTruthy();
+    expect(queryByLabelText('Custom Last Name')).toBeTruthy();
   });
 });

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rollup-plugin-babel": "^4.3.2",
     "sanitize.css": "^8.0.0",
     "yargs": "^13.2.1",
-    "zapier-scripts": "^5.0.0"
+    "zapier-scripts": "^6.2.0"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.3.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gh-pages": "^2.0.1",
     "isomorphic-unfetch": "^2.1.1",
     "jest": "^23.6.0",
+    "jest-dom": "^3.2.2",
     "jest-serializer-html": "^6.0.0",
     "next": "^8.0.1",
     "next-plugin-custom-babel-config": "^1.0.0",

--- a/setup-jest-env.js
+++ b/setup-jest-env.js
@@ -1,5 +1,6 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import 'jest-dom/extend-expect';
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/src/future/ReactiveValue.js
+++ b/src/future/ReactiveValue.js
@@ -59,9 +59,11 @@ class ReactiveValue {
   }
 
   updateMeta() {
-    this.meta = null;
-    this.hasMetaChanged = true;
-    this.getMeta();
+    if (this.meta) {
+      this.meta = null;
+      this.hasMetaChanged = true;
+      this.getMeta();
+    }
   }
 
   // Set property value and recurse up through parents.

--- a/src/future/ReactiveValue.js
+++ b/src/future/ReactiveValue.js
@@ -189,14 +189,11 @@ export function ReactiveValueContainer({ value, onChange, children }) {
     valueRef.current.setValue(value);
   });
   // Any time our wrapper's value changes, kick off our onChange handler.
-  useEffect(
-    () => {
-      return typeof onChange === 'function'
-        ? valueRef.current.subscribe(onChange)
-        : () => {};
-    },
-    [onChange]
-  );
+  useEffect(() => {
+    return typeof onChange === 'function'
+      ? valueRef.current.subscribe(onChange)
+      : () => {};
+  }, [onChange]);
   return (
     <ReactiveValueContext.Provider value={valueRef.current}>
       {children}
@@ -209,12 +206,9 @@ export function ReactiveValueContainer({ value, onChange, children }) {
 function useChildReactiveValue(key) {
   const parentReactiveValue = useContext(ReactiveValueContext);
   const childReactiveValue = parentReactiveValue.getChild(key);
-  useEffect(
-    () => {
-      return childReactiveValue.hold();
-    },
-    [key]
-  );
+  useEffect(() => {
+    return childReactiveValue.hold();
+  }, [childReactiveValue, key]);
   return childReactiveValue;
 }
 
@@ -222,14 +216,11 @@ function useChildReactiveValue(key) {
 export function useReactiveValueAt(key) {
   const childReactiveValue = useChildReactiveValue(key);
   const [value, setValue] = useState(() => childReactiveValue.getValue());
-  useEffect(
-    () => {
-      // Subscribe to changes to the property and set our value in state when
-      // that property changes.
-      return childReactiveValue.subscribe(setValue);
-    },
-    [key]
-  );
+  useEffect(() => {
+    // Subscribe to changes to the property and set our value in state when
+    // that property changes.
+    return childReactiveValue.subscribe(setValue);
+  }, [childReactiveValue, key]);
   function setValueInContext(newValue) {
     childReactiveValue.setValue(newValue);
   }
@@ -245,7 +236,7 @@ export function useReactiveValue() {
     // Subscribe to changes to the whoile value property and set our value in
     // state when that property changes.
     return reactiveValue.subscribe(setValue);
-  }, []);
+  }, [reactiveValue]);
   function setValueInContext(newValue) {
     reactiveValue.setValue(newValue);
   }
@@ -258,7 +249,7 @@ export function useReactiveValueMeta() {
   const [meta, setMeta] = useState(() => reactiveValue.getMeta());
   useEffect(() => {
     return reactiveValue.subscribeMeta(setMeta);
-  }, []);
+  }, [reactiveValue]);
   return meta;
 }
 

--- a/src/future/ReactiveValue.test.js
+++ b/src/future/ReactiveValue.test.js
@@ -330,3 +330,37 @@ test('should notify when property types change', () => {
     'firstName:string,lastName:string,age:number'
   );
 });
+
+test('should notify when keys change', () => {
+  function PropertyTypes() {
+    const meta = useReactiveValueMeta();
+    return (
+      <div data-testid="meta">
+        {Object.entries(meta.propertyTypes)
+          .map(([key, type]) => `${key}:${type}`)
+          .join(',')}
+      </div>
+    );
+  }
+
+  const { getByTestId, rerender } = render(
+    <ReactiveValueContainer onChange={() => {}} value={{ firstName: 'Ron' }}>
+      <PropertyTypes />
+    </ReactiveValueContainer>
+  );
+
+  expect(getByTestId('meta').textContent).toBe('firstName:string');
+
+  rerender(
+    <ReactiveValueContainer
+      onChange={() => {}}
+      value={{ firstName: 'Ron', lastName: 'Burgundy' }}
+    >
+      <PropertyTypes />
+    </ReactiveValueContainer>
+  );
+
+  expect(getByTestId('meta').textContent).toBe(
+    'firstName:string,lastName:string'
+  );
+});

--- a/src/future/ReactiveValue.test.js
+++ b/src/future/ReactiveValue.test.js
@@ -52,12 +52,10 @@ test('should notify of a change to a property', () => {
   fireEvent.change(getByTestId('firstName'), {
     target: { value: 'Joe' },
   });
-  expect(onChangeSpy.mock.calls[0]).toEqual([
-    {
-      firstName: 'Joe',
-      lastName: '',
-    },
-  ]);
+  expect(onChangeSpy).toHaveBeenLastCalledWith({
+    firstName: 'Joe',
+    lastName: '',
+  });
 });
 
 test(`should avoid signaling hook for properties that don't change`, () => {
@@ -86,14 +84,12 @@ test(`should avoid signaling hook for properties that don't change`, () => {
   fireEvent.change(getByTestId('firstName'), {
     target: { value: 'Joe' },
   });
-  expect(onChangeSpy.mock.calls[0]).toEqual([
-    {
-      firstName: 'Joe',
-      lastName: '',
-    },
-  ]);
-  expect(firstNameRenderSpy.mock.calls.length).toBe(2);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(1);
+  expect(onChangeSpy).toHaveBeenLastCalledWith({
+    firstName: 'Joe',
+    lastName: '',
+  });
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(2);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(1);
 });
 
 test(`should avoid unnecessary renders as controlled component`, () => {
@@ -135,11 +131,11 @@ test(`should avoid unnecessary renders as controlled component`, () => {
   fireEvent.change(getByTestId('firstName'), {
     target: { value: 'Joe' },
   });
-  expect(firstNameRenderSpy.mock.calls.length).toBe(2);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(1);
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(2);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(1);
   fireEvent.click(getByTestId('upperCase'));
-  expect(firstNameRenderSpy.mock.calls.length).toBe(3);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(1);
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(3);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(1);
 });
 
 test(`should work with nesting, with no wasted renders`, () => {
@@ -182,36 +178,32 @@ test(`should work with nesting, with no wasted renders`, () => {
   fireEvent.change(getByTestId('firstName'), {
     target: { value: 'Joe' },
   });
-  expect(onChangeSpy.mock.calls[0]).toEqual([
-    {
-      name: {
-        firstName: 'Joe',
-        lastName: '',
-      },
-      age: 50,
+  expect(onChangeSpy).toHaveBeenLastCalledWith({
+    name: {
+      firstName: 'Joe',
+      lastName: '',
     },
-  ]);
-  expect(firstNameRenderSpy.mock.calls.length).toBe(2);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(1);
-  expect(nameRenderSpy.mock.calls.length).toBe(1);
-  expect(ageRenderSpy.mock.calls.length).toBe(1);
+    age: 50,
+  });
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(2);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(1);
+  expect(nameRenderSpy).toHaveBeenCalledTimes(1);
+  expect(ageRenderSpy).toHaveBeenCalledTimes(1);
   fireEvent.change(getByTestId('age'), {
     // See above where we coerce value.
     target: { value: '51' },
   });
-  expect(onChangeSpy.mock.calls[1]).toEqual([
-    {
-      name: {
-        firstName: 'Joe',
-        lastName: '',
-      },
-      age: 51,
+  expect(onChangeSpy).toHaveBeenLastCalledWith({
+    name: {
+      firstName: 'Joe',
+      lastName: '',
     },
-  ]);
-  expect(firstNameRenderSpy.mock.calls.length).toBe(2);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(1);
-  expect(nameRenderSpy.mock.calls.length).toBe(1);
-  expect(ageRenderSpy.mock.calls.length).toBe(2);
+    age: 51,
+  });
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(2);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(1);
+  expect(nameRenderSpy).toHaveBeenCalledTimes(1);
+  expect(ageRenderSpy).toHaveBeenCalledTimes(2);
 });
 
 test(`should be able to subscribe to the whole value`, () => {
@@ -245,13 +237,13 @@ test(`should be able to subscribe to the whole value`, () => {
       <Name />
     </ReactiveValueContainer>
   );
-  expect(firstNameRenderSpy.mock.calls.length).toBe(1);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(1);
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(1);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(1);
   fireEvent.change(getByTestId('firstName'), {
     target: { value: 'Joe' },
   });
-  expect(firstNameRenderSpy.mock.calls.length).toBe(2);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(1);
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(2);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(1);
   expect(getByTestId('name').value).toBe(
     JSON.stringify({
       firstName: 'Joe',
@@ -266,8 +258,8 @@ test(`should be able to subscribe to the whole value`, () => {
       }),
     },
   });
-  expect(firstNameRenderSpy.mock.calls.length).toBe(2);
-  expect(lastNameRenderSpy.mock.calls.length).toBe(2);
+  expect(firstNameRenderSpy).toHaveBeenCalledTimes(2);
+  expect(lastNameRenderSpy).toHaveBeenCalledTimes(2);
 });
 
 test('should notify when property types change', () => {
@@ -306,7 +298,7 @@ test('should notify when property types change', () => {
       <PropertyTypes />
     </ReactiveValueContainer>
   );
-  expect(getByTestId('meta').textContent).toBe(
+  expect(getByTestId('meta')).toHaveTextContent(
     'firstName:string,lastName:string'
   );
   fireEvent.change(getByTestId('firstName'), {
@@ -316,7 +308,7 @@ test('should notify when property types change', () => {
     firstName: 'Joe',
     lastName: '',
   });
-  expect(propertyTypesRenderSpy.mock.calls.length).toBe(1);
+  expect(propertyTypesRenderSpy).toHaveBeenCalledTimes(1);
   fireEvent.change(getByTestId('age'), {
     target: { value: 50 },
   });
@@ -325,8 +317,8 @@ test('should notify when property types change', () => {
     lastName: '',
     age: 50,
   });
-  expect(propertyTypesRenderSpy.mock.calls.length).toBe(2);
-  expect(getByTestId('meta').textContent).toBe(
+  expect(propertyTypesRenderSpy).toHaveBeenCalledTimes(2);
+  expect(getByTestId('meta')).toHaveTextContent(
     'firstName:string,lastName:string,age:number'
   );
 });
@@ -349,7 +341,7 @@ test('should notify when keys change', () => {
     </ReactiveValueContainer>
   );
 
-  expect(getByTestId('meta').textContent).toBe('firstName:string');
+  expect(getByTestId('meta')).toHaveTextContent('firstName:string');
 
   rerender(
     <ReactiveValueContainer
@@ -360,7 +352,7 @@ test('should notify when keys change', () => {
     </ReactiveValueContainer>
   );
 
-  expect(getByTestId('meta').textContent).toBe(
+  expect(getByTestId('meta')).toHaveTextContent(
     'firstName:string,lastName:string'
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,6 +1483,13 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
@@ -1686,10 +1693,10 @@
   resolved "https://registry.yarnpkg.com/@zapier/browserslist-config-zapier/-/browserslist-config-zapier-1.0.2.tgz#ba55896674e99d05c2841938b38768079dddc40a"
   integrity sha512-kV+KPL46xZqlKL8GuC0J3KGgoo2YNg+tiJd8ubLTEjq5s+7aWm9da/VSalkuTKgFKxA1YsO3uzi++7St9PavAw==
 
-"@zapier/eslint-plugin-zapier@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@zapier/eslint-plugin-zapier/-/eslint-plugin-zapier-8.0.0.tgz#ff217f9944b1b8e07aee293a081ce54d8de395c3"
-  integrity sha512-UjlBgZA4lhouFUWUyCiTohHWtmnmf/+taR2mty8/RymkBCjJJliwbgL0zjZJCUmHvB4MJcMoUaVemE8jh3F9Ag==
+"@zapier/eslint-plugin-zapier@^9.0.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@zapier/eslint-plugin-zapier/-/eslint-plugin-zapier-9.1.0.tgz#1e646111e447d7fc7c4993e9ca6eec1a7a7dba07"
+  integrity sha512-rmlRryKOwdpczdSN3eJsd9rBkQbq+Aq/+YKLyP0cAHOdBlFj/K78vu37sjl17cr/MxUVeQ9Bh2iDYfT2yu7FfA==
   dependencies:
     babel-eslint "^8.1.2"
     eslint "^4.14.0"
@@ -1697,6 +1704,7 @@
     eslint-plugin-flowtype "2.35.0"
     eslint-plugin-jsx-a11y "6.2.1"
     eslint-plugin-react "7.3.0"
+    eslint-plugin-react-hooks "^1.3.0"
     requireindex "^1.1.0"
 
 "@zeit/next-css@^1.0.1":
@@ -1850,6 +1858,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
 any-promise@^1.1.0:
   version "1.3.0"
@@ -2835,7 +2848,7 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -2954,12 +2967,20 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
-cli-cursor@^2.1.0:
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -3359,6 +3380,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -3681,6 +3707,11 @@ electron-to-chromium@^1.3.103:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
   integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
 
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
 elliptic@^6.0.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
@@ -3889,6 +3920,11 @@ eslint-plugin-jsx-a11y@6.2.1:
     emoji-regex "^7.0.2"
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
+
+eslint-plugin-react-hooks@^1.3.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
 
 eslint-plugin-react@7.3.0:
   version "7.3.0"
@@ -4317,6 +4353,14 @@ figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
   integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
+
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -5459,6 +5503,13 @@ is-number@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -6246,6 +6297,50 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
+
+listr@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -6360,6 +6455,22 @@ lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -7332,6 +7443,11 @@ p-map@^1.1.1:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
   integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
+p-map@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -7677,10 +7793,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
-  integrity sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==
+prettier@1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 pretty-format@^23.6.0:
   version "23.6.0"
@@ -8604,6 +8720,13 @@ rxjs@^6.1.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.3.3:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
+  integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -8829,6 +8952,11 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -9258,6 +9386,11 @@ svgo@^0.7.2:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
+
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.2"
@@ -9932,6 +10065,14 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -10054,14 +10195,14 @@ yargs@^13.2.1:
     y18n "^4.0.0"
     yargs-parser "^13.0.0"
 
-zapier-scripts@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/zapier-scripts/-/zapier-scripts-5.0.0.tgz#a40cb5410b46a4b15e1a21feb244d96de5ae0bd6"
-  integrity sha512-CugmZSNhFSaPtxgk3izkO64nQSE4DMDjRgvewCMaydHA03q+rhzVqtoAJ+lrkzzcFXgTWDz2B5zPix7KjeMEdQ==
+zapier-scripts@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/zapier-scripts/-/zapier-scripts-6.2.0.tgz#879d0a91e7ec96ede5189524cb1c7279a536efd1"
+  integrity sha512-cQI9JNi2oqHvxJyT3DljCZPGVBwjWatlJQsIhh7yPt8/mEwXe71T2MXw3dwMeRaGvo9GCuawyNQTIBlfoyiYFw==
   dependencies:
     "@babel/core" "^7.1.2"
     "@zapier/babel-preset-zapier" "^5.2.2"
-    "@zapier/eslint-plugin-zapier" "^8.0.0"
+    "@zapier/eslint-plugin-zapier" "^9.0.0"
     babel-core "7.0.0-bridge.0"
     babel-jest "^23.4.2"
     babel-plugin-require-context-hook "^1.0.0"
@@ -10069,12 +10210,14 @@ zapier-scripts@^5.0.0:
     enzyme-adapter-react-16 "^1.7.0"
     enzyme-to-json "^3.3.4"
     eslint "^4.8.0"
+    execa "^1.0.0"
     husky "^0.14.3"
     is-ci "^1.2.1"
     jest "^23.6.0"
     jest-transform-graphql "^2.1.0"
+    listr "^0.14.3"
     lodash.without "^4.4.0"
-    prettier "1.14.2"
+    prettier "1.16.4"
     raf "^3.4.1"
     react "^16.6.3"
     react-dom "^16.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,6 +1470,15 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
+"@jest/types@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.8.0.tgz#f31e25948c58f0abd8c845ae26fcea1491dea7ad"
+  integrity sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^12.0.9"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -1500,10 +1509,30 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/istanbul-lib-coverage@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
+  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
+
 "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
   integrity sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==
+
+"@types/istanbul-lib-report@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
+  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
+  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
 
 "@types/node@*":
   version "11.9.4"
@@ -3317,6 +3346,21 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -3562,6 +3606,11 @@ detect-port-alt@1.1.6:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+diff-sequences@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
+  integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
 diff@^3.2.0:
   version "3.5.0"
@@ -5807,12 +5856,36 @@ jest-diff@^23.6.0:
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
 
+jest-diff@^24.0.0, jest-diff@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
+  integrity sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.3.0"
+    jest-get-type "^24.8.0"
+    pretty-format "^24.8.0"
+
 jest-docblock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
   integrity sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=
   dependencies:
     detect-newline "^2.1.0"
+
+jest-dom@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-3.2.2.tgz#4876c173045ae040f12220c56eb2555ef328fd94"
+  integrity sha512-Fnq3Y6d0MoDAJV8pAXkqe/e4VTBihRGaJypXvaHTLL9oRYzOvz0Q04evi5SBwPQ7FBiujQQOPXoEgEBGTg5BaA==
+  dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^2.0.0"
 
 jest-each@^23.6.0:
   version "23.6.0"
@@ -5843,6 +5916,11 @@ jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
   integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
+
+jest-get-type@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.8.0.tgz#a7440de30b651f5a70ea3ed7ff073a32dfe646fc"
+  integrity sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==
 
 jest-haste-map@^23.6.0:
   version "23.6.0"
@@ -5891,6 +5969,16 @@ jest-matcher-utils@^23.6.0:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
+
+jest-matcher-utils@^24.0.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
+  integrity sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.8.0"
+    jest-get-type "^24.8.0"
+    pretty-format "^24.8.0"
 
 jest-message-util@^23.4.0:
   version "23.4.0"
@@ -7806,6 +7894,16 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^24.0.0, pretty-format@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
+  integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
+  dependencies:
+    "@jest/types" "^24.8.0"
+    ansi-regex "^4.0.0"
+    ansi-styles "^3.2.0"
+    react-is "^16.8.4"
+
 pretty-format@^24.5.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.7.0.tgz#d23106bc2edcd776079c2daa5da02bcb12ed0c10"
@@ -9019,7 +9117,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==


### PR DESCRIPTION
Fixes a minor bug with `setValue`. We now update meta when the root value is updated.

Additional commits are noted. But one add is `jest-dom` which includes some convenience [matchers](https://github.com/testing-library/jest-dom#table-of-contents) to `expect` 
