### PR TITLE
Do not fire the onChange event in pretty-text-input when no changes.

### DIFF
--- a/src/components/helpers/pretty-text-input.js
+++ b/src/components/helpers/pretty-text-input.js
@@ -535,7 +535,9 @@ export default createReactClass({
       this.debouncedOnChangeAndTagCodeMirror = null;
 
       // Flush changes
-      this.onChange(this.codeMirror.getValue());
+      if (this.isDebouncingCodeMirrorChange) {
+        this.onChange(this.codeMirror.getValue());
+      }
     }
 
     this.codeMirror = null;


### PR DESCRIPTION
Do not fire the onChange event in pretty-text-input helper when there are no changes waiting to be debounced. Doing so can cause bugs in client applications that depend on onChange only being fired when the user actually changes something.