### PR TITLE
Limit height of choices accordion to fit within its container

### DIFF
--- a/__tests__/components/fields/__snapshots__/pretty-select.js.snap
+++ b/__tests__/components/fields/__snapshots__/pretty-select.js.snap
@@ -506,7 +506,7 @@ exports[`pretty-select field should render open choices correctly (Alphabet) 1`]
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -887,7 +887,7 @@ exports[`pretty-select field should render open choices correctly (Colors (R)) 1
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -991,7 +991,7 @@ exports[`pretty-select field should render open choices correctly (Colors 2) 1`]
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1084,7 +1084,7 @@ exports[`pretty-select field should render open choices correctly (Colors 3) 1`]
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -1235,7 +1235,7 @@ exports[`pretty-select field should render open choices correctly (Empty) 1`] = 
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1308,7 +1308,7 @@ exports[`pretty-select field should render open choices correctly (Loading) 1`] 
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1443,7 +1443,7 @@ exports[`pretty-select field should render open choices correctly (Select with N
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1545,7 +1545,7 @@ exports[`pretty-select field should render open choices correctly (Select with S
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -1708,7 +1708,7 @@ exports[`pretty-select field should render open choices correctly (Size) 1`] = `
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -1815,7 +1815,7 @@ exports[`pretty-select field should render open choices correctly (Yes/No) 1`] =
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute; max-height: 768px;"
+               style="user-select: none; position: absolute;"
           >
             <div class="choices-search">
               <input placeholder="Search..."

--- a/__tests__/components/fields/__snapshots__/pretty-select.js.snap
+++ b/__tests__/components/fields/__snapshots__/pretty-select.js.snap
@@ -506,7 +506,7 @@ exports[`pretty-select field should render open choices correctly (Alphabet) 1`]
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -887,7 +887,7 @@ exports[`pretty-select field should render open choices correctly (Colors (R)) 1
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -991,7 +991,7 @@ exports[`pretty-select field should render open choices correctly (Colors 2) 1`]
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1084,7 +1084,7 @@ exports[`pretty-select field should render open choices correctly (Colors 3) 1`]
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -1235,7 +1235,7 @@ exports[`pretty-select field should render open choices correctly (Empty) 1`] = 
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1308,7 +1308,7 @@ exports[`pretty-select field should render open choices correctly (Loading) 1`] 
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1443,7 +1443,7 @@ exports[`pretty-select field should render open choices correctly (Select with N
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <ul class="choices">
               <li class="choice">
@@ -1545,7 +1545,7 @@ exports[`pretty-select field should render open choices correctly (Select with S
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -1708,7 +1708,7 @@ exports[`pretty-select field should render open choices correctly (Size) 1`] = `
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <div class="choices-search">
               <input placeholder="Search..."
@@ -1815,7 +1815,7 @@ exports[`pretty-select field should render open choices correctly (Yes/No) 1`] =
           </div>
           <div class="choices-container"
                role="presentation"
-               style="user-select: none; position: absolute;"
+               style="user-select: none; position: absolute; max-height: 768px;"
           >
             <div class="choices-search">
               <input placeholder="Search..."

--- a/src/components/helpers/choices.js
+++ b/src/components/helpers/choices.js
@@ -256,7 +256,7 @@ export default createReactClass({
       const clampedHeight = Math.min(Math.abs(propsMaxHeight), 1);
       const actualHeight = windowHeight - top;
       const desiredMaxHeight = actualHeight * clampedHeight;
-      if (actualHeight !== desiredMaxHeight) {
+      if (Math.round(actualHeight) !== Math.round(desiredMaxHeight)) {
         didSetState = true;
         this.setState(
           {

--- a/src/components/helpers/choices.js
+++ b/src/components/helpers/choices.js
@@ -253,7 +253,7 @@ export default createReactClass({
       const clampedRatio = Math.min(Math.abs(maxHeightRatio), 1);
       const actualHeight = windowHeight - top;
       const desiredMaxHeight = actualHeight * clampedRatio;
-      if (Math.round(actualHeight) !== Math.round(desiredMaxHeight)) {
+      if (Math.round(desiredMaxHeight) !== Math.round(this.state.maxHeight)) {
         didSetState = true;
         this.setState(
           {

--- a/src/components/helpers/choices.js
+++ b/src/components/helpers/choices.js
@@ -249,7 +249,7 @@ export default createReactClass({
       const rect = node.getBoundingClientRect();
       const top = rect.top;
       const windowHeight = window.innerHeight;
-      const height = windowHeight - top;
+      const height = (windowHeight - top) * 0.75;
       if (height !== this.state.maxHeight) {
         didSetState = true;
         this.setState(

--- a/src/components/helpers/choices.js
+++ b/src/components/helpers/choices.js
@@ -249,12 +249,18 @@ export default createReactClass({
       const rect = node.getBoundingClientRect();
       const top = rect.top;
       const windowHeight = window.innerHeight;
-      const height = (windowHeight - top) * 0.75;
-      if (height !== this.state.maxHeight) {
+      const propsMaxHeight =
+        this.props.field && this.props.field.meta
+          ? this.props.field.meta.choicesMaxHeight
+          : 1;
+      const clampedHeight = Math.min(Math.abs(propsMaxHeight), 1);
+      const actualHeight = windowHeight - top;
+      const desiredMaxHeight = actualHeight * clampedHeight;
+      if (actualHeight !== desiredMaxHeight) {
         didSetState = true;
         this.setState(
           {
-            maxHeight: height,
+            maxHeight: desiredMaxHeight,
           },
           cb
         );

--- a/src/components/helpers/choices.js
+++ b/src/components/helpers/choices.js
@@ -249,10 +249,10 @@ export default createReactClass({
       const rect = node.getBoundingClientRect();
       const top = rect.top;
       const windowHeight = window.innerHeight;
-      const propsMaxHeight = this.props.config.getChoicesMaxHeightRatio();
-      const clampedHeight = Math.min(Math.abs(propsMaxHeight), 1);
+      const maxHeightRatio = this.props.config.getChoicesMaxHeightRatio();
+      const clampedRatio = Math.min(Math.abs(maxHeightRatio), 1);
       const actualHeight = windowHeight - top;
-      const desiredMaxHeight = actualHeight * clampedHeight;
+      const desiredMaxHeight = actualHeight * clampedRatio;
       if (Math.round(actualHeight) !== Math.round(desiredMaxHeight)) {
         didSetState = true;
         this.setState(

--- a/src/components/helpers/choices.js
+++ b/src/components/helpers/choices.js
@@ -249,10 +249,7 @@ export default createReactClass({
       const rect = node.getBoundingClientRect();
       const top = rect.top;
       const windowHeight = window.innerHeight;
-      const propsMaxHeight =
-        this.props.field && this.props.field.meta
-          ? this.props.field.meta.choicesMaxHeight
-          : 1;
+      const propsMaxHeight = this.props.config.getChoicesMaxHeightRatio();
       const clampedHeight = Math.min(Math.abs(propsMaxHeight), 1);
       const actualHeight = windowHeight - top;
       const desiredMaxHeight = actualHeight * clampedHeight;

--- a/src/default-config.js
+++ b/src/default-config.js
@@ -1283,5 +1283,9 @@ export default function(config) {
       }
       return require('codemirror');
     },
+
+    getChoicesMaxHeightRatio() {
+      return 1;
+    },
   };
 }


### PR DESCRIPTION
### Description

This PR shortens the max height at which an accordion can open. 

Previously, it could expand to be the entire height of its container (from the top of the containing rect).

This meant that the dropdown would often expand past the viewbox and users would have to scroll down to see all the options in the dropdown.

This PR fixes that by making the max height 75% of the height of its container, so that it is always contained within the viewport.


### Before

![](https://cdn.zapier.com/storage/photos/169c67e6f89dd5e6cb77e056f5ea8a7d.png)

### After

![](https://cdn.zapier.com/storage/photos/8bad433c7e603c5380138b9552e5ca07_2.png)
