### PR TITLE
Fix bug trying ta tag non-existing CodeMirror instance.

### DIFF
--- a/src/components/helpers/pretty-text-input.js
+++ b/src/components/helpers/pretty-text-input.js
@@ -417,7 +417,12 @@ export default createReactClass({
 
     this.debouncedOnChangeAndTagCodeMirror = _.debounce(() => {
       this.isDebouncingCodeMirrorChange = false;
-      this.onChangeAndTagCodeMirror();
+
+      // If this.codeMirror no longer exists don't tag, to avoid this error:
+      // https://cdn.zapier.com/storage/photos/69d375365045c5fd6e9c7e2a68c43905.png
+      if (this.codeMirror) {
+        this.onChangeAndTagCodeMirror();
+      }
     }, 200);
 
     const pos = this.codeMirror ? this.codeMirror.getCursor() : null;


### PR DESCRIPTION
Sometimes we see this error in the console:

![](https://cdn.zapier.com/storage/photos/69d375365045c5fd6e9c7e2a68c43905.png)

This happens when the debounced method to tag the CodeMirror editor tries tag this.codeMirror after the component has unmounted and this.codeMirror has been set to null on componentWillUnmount. To fix, bail out of the method if `this.codeMirror` is not defined.

Fixing this might reduce some sentry errors.